### PR TITLE
feat(security): ephemeral credential constants and forbidden-env guard

### DIFF
--- a/quell/core/verifier.py
+++ b/quell/core/verifier.py
@@ -48,6 +48,9 @@ from quell.core.models import (
     VerificationResult,
     VerificationStatus,
 )
+from quell.infra.specs import _assert_no_credential_reads
+
+_assert_no_credential_reads()
 
 
 def _resolve_pytest_cmd() -> list[str]:

--- a/quell/infra/__init__.py
+++ b/quell/infra/__init__.py
@@ -1,0 +1,1 @@
+"""quell.infra — ephemeral container engine and dependency registry."""

--- a/quell/infra/specs.py
+++ b/quell/infra/specs.py
@@ -1,0 +1,241 @@
+"""
+Security model, ephemeral credential constants, and import-to-infra tag registry.
+
+DESIGN RULE: quelltest NEVER reads, prompts for, or touches production credentials.
+All containers start with EPHEMERAL_CREDS — hardcoded, throwaway, non-configurable.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Ephemeral credentials — the ONLY credentials quelltest ever uses
+# ---------------------------------------------------------------------------
+
+EPHEMERAL_CREDS: dict[str, dict[str, str | None]] = {
+    "postgres":   {"user": "quell", "password": "quell_eph", "db": "quell_test"},
+    "redis":      {"password": None},
+    "mongo":      {"user": "quell", "password": "quell_eph", "db": "quell_test"},
+    "mysql":      {"user": "quell", "password": "quell_eph", "db": "quell_test"},
+    "localstack": {"access_key": "test", "secret_key": "test", "region": "us-east-1"},
+}
+
+# ---------------------------------------------------------------------------
+# Forbidden env vars — real credentials that quelltest deliberately ignores
+# ---------------------------------------------------------------------------
+
+FORBIDDEN_ENV_READS: list[str] = [
+    "DATABASE_URL", "DB_URL", "POSTGRES_URL", "MYSQL_URL",
+    "REDIS_URL", "REDIS_HOST", "REDIS_PASSWORD",
+    "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+    "MONGODB_URI", "MONGO_URL", "SECRET_KEY", "API_KEY",
+]
+
+_TRUST_MSG = """\
+┌────────────────────────────────────────────────────────┐
+│  quelltest infrastructure isolation                    │
+│                                                        │
+│  ✓ Starting throwaway container (ephemeral creds)      │
+│  ✓ No connection to your real database                 │
+│  ✓ Container destroyed after this run                  │
+│                                                        │
+│  quelltest never reads or stores your real             │
+│  database credentials or connection strings.           │
+└────────────────────────────────────────────────────────┘"""
+
+_TRUST_FLAG = Path(".quellgraph") / "trust_shown"
+
+
+def _assert_no_credential_reads() -> None:
+    """Log that real env vars are deliberately ignored. Never raises."""
+    for key in FORBIDDEN_ENV_READS:
+        if key in os.environ:
+            logger.debug("quelltest: ignoring %s (using ephemeral container instead)", key)
+
+
+def show_trust_message_once() -> None:
+    """Print the isolation trust message on first run per project."""
+    if _TRUST_FLAG.exists():
+        return
+    print(_TRUST_MSG)
+    try:
+        _TRUST_FLAG.parent.mkdir(parents=True, exist_ok=True)
+        _TRUST_FLAG.touch()
+    except OSError:
+        pass  # non-fatal
+
+
+# ---------------------------------------------------------------------------
+# Import → infra tag map  (used by QuellGraph builder)
+# ---------------------------------------------------------------------------
+
+IMPORT_SIGNALS: dict[str, str] = {
+    # PostgreSQL
+    "sqlalchemy": "postgres",
+    "databases": "postgres",
+    "asyncpg": "postgres",
+    "psycopg2": "postgres",
+    "psycopg": "postgres",
+    "tortoise": "postgres",
+    "alembic": "postgres",
+    # MySQL
+    "pymysql": "mysql",
+    "aiomysql": "mysql",
+    # MongoDB
+    "motor": "mongo",
+    "pymongo": "mongo",
+    "beanie": "mongo",
+    # Redis / cache / broker
+    "redis": "redis",
+    "aioredis": "redis",
+    "celery": "redis",   # default broker; overridden if pika also present
+    "kombu": "redis",
+    # AWS / object storage
+    "boto3": "localstack",
+    "botocore": "localstack",
+    "aiobotocore": "localstack",
+    "s3fs": "localstack",
+    # Search
+    "elasticsearch": "elasticsearch",
+    "opensearchpy": "opensearch",
+    # Message queue
+    "pika": "rabbitmq",
+    "aio_pika": "rabbitmq",
+    # Email
+    "smtplib": "smtp",
+    "aiosmtplib": "smtp",
+}
+
+# Infra parameter type names — catches dependency-injected infra
+INFRA_TYPE_NAMES: dict[str, str] = {
+    "Session": "postgres",
+    "AsyncSession": "postgres",
+    "Connection": "postgres",
+    "AsyncConnection": "postgres",
+    "Redis": "redis",
+    "StrictRedis": "redis",
+    "AsyncRedis": "redis",
+    "MongoClient": "mongo",
+    "AsyncIOMotorClient": "mongo",
+    "S3Client": "localstack",
+    "DynamoDBClient": "localstack",
+    "Elasticsearch": "elasticsearch",
+    "BlockingConnection": "rabbitmq",
+    "Channel": "rabbitmq",
+}
+
+# ---------------------------------------------------------------------------
+# Container specs registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ContainerSpec:
+    """Configuration for one type of ephemeral infrastructure container."""
+
+    tag: str                        # e.g. "postgres"
+    image: str                      # e.g. "postgres:16"
+    fixture_name: str               # e.g. "_quell_pg"
+    port: int
+    wait_strategy: str              # "log" | "http" | "port"
+    wait_value: str                 # log line or HTTP path to probe
+    connection_env_key: str         # env var injected into the test subprocess
+    connection_url_template: str    # format with {host} and {port}
+    extra_imports: list[str] = field(default_factory=list)
+    env_vars: dict[str, str] = field(default_factory=dict)
+
+
+CONTAINER_SPECS: dict[str, ContainerSpec] = {
+    "postgres": ContainerSpec(
+        tag="postgres",
+        image="postgres:16",
+        fixture_name="_quell_pg",
+        port=5432,
+        wait_strategy="log",
+        wait_value="database system is ready to accept connections",
+        connection_env_key="DATABASE_URL",
+        connection_url_template=(
+            "postgresql://quell:quell_eph@{host}:{port}/quell_test"
+        ),
+        extra_imports=[
+            "from sqlalchemy import create_engine",
+            "from sqlalchemy.orm import sessionmaker",
+        ],
+    ),
+    "redis": ContainerSpec(
+        tag="redis",
+        image="redis:7",
+        fixture_name="_quell_redis",
+        port=6379,
+        wait_strategy="log",
+        wait_value="Ready to accept connections",
+        connection_env_key="REDIS_URL",
+        connection_url_template="redis://{host}:{port}/0",
+        extra_imports=["import redis as _redis_lib"],
+    ),
+    "localstack": ContainerSpec(
+        tag="localstack",
+        image="localstack/localstack:3",
+        fixture_name="_quell_localstack",
+        port=4566,
+        wait_strategy="http",
+        wait_value="/_localstack/health",
+        connection_env_key="AWS_ENDPOINT_URL",
+        connection_url_template="http://{host}:{port}",
+        extra_imports=["import boto3"],
+        env_vars={"SERVICES": "s3,sqs,dynamodb"},
+    ),
+    "mongo": ContainerSpec(
+        tag="mongo",
+        image="mongo:7",
+        fixture_name="_quell_mongo",
+        port=27017,
+        wait_strategy="log",
+        wait_value="Waiting for connections",
+        connection_env_key="MONGODB_URL",
+        connection_url_template="mongodb://quell:quell_eph@{host}:{port}",
+        extra_imports=["from pymongo import MongoClient"],
+    ),
+    "smtp": ContainerSpec(
+        tag="smtp",
+        image="axllent/mailpit:latest",
+        fixture_name="_quell_smtp",
+        port=1025,
+        wait_strategy="port",
+        wait_value="",
+        connection_env_key="SMTP_HOST",
+        connection_url_template="{host}:{port}",
+        extra_imports=[],
+    ),
+    "rabbitmq": ContainerSpec(
+        tag="rabbitmq",
+        image="rabbitmq:3-management",
+        fixture_name="_quell_rabbitmq",
+        port=5672,
+        wait_strategy="log",
+        wait_value="Server startup complete",
+        connection_env_key="BROKER_URL",
+        connection_url_template="amqp://guest:guest@{host}:{port}//",
+        extra_imports=[],
+    ),
+    "elasticsearch": ContainerSpec(
+        tag="elasticsearch",
+        image="elasticsearch:8.13.0",
+        fixture_name="_quell_es",
+        port=9200,
+        wait_strategy="http",
+        wait_value="/_cluster/health",
+        connection_env_key="ELASTICSEARCH_URL",
+        connection_url_template="http://{host}:{port}",
+        extra_imports=["from elasticsearch import Elasticsearch"],
+        env_vars={
+            "discovery.type": "single-node",
+            "xpack.security.enabled": "false",
+        },
+    ),
+}

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -1,0 +1,249 @@
+"""Create quell_spec6 issues in quelltest/quelltest_lib upstream."""
+import json
+import os
+import urllib.request
+import ssl
+
+TOKEN = os.environ["GITHUB_TOKEN"]
+REPO = "quelltest/quelltest_lib"
+ASSIGNEE = "shashankbindal"
+BASE = f"https://api.github.com/repos/{REPO}"
+CTX = ssl.create_default_context()
+
+
+def post(endpoint: str, payload: dict) -> dict:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{BASE}/{endpoint}",
+        data=data,
+        headers={
+            "Authorization": f"token {TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, context=CTX) as r:
+        return json.load(r)
+
+
+ISSUES = [
+    {
+        "title": "feat: add security model — ephemeral credential constants and forbidden-env guard",
+        "labels": ["security", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add `EPHEMERAL_CREDS` hardcoded constants (postgres/redis/mongo/mysql/localstack) "
+            "and a `FORBIDDEN_ENV_READS` guard that logs and ignores real production env vars at "
+            "startup. Show a one-time trust message stored in `.quellgraph/trust_shown`.\n\n"
+            "## Why\n"
+            "quelltest must never touch real credentials. "
+            "This is the non-negotiable security foundation for the container engine.\n\n"
+            "## Files\n"
+            "- `quell/infra/specs.py` (new) — `EPHEMERAL_CREDS`, `FORBIDDEN_ENV_READS`, `_assert_no_credential_reads()`\n"
+            "- `quell/core/verifier.py` — call guard at startup\n\n"
+            "## Acceptance Criteria\n"
+            "- 13 forbidden env var names checked and logged (not raised) at startup\n"
+            "- Trust message shown once; suppressed after `.quellgraph/trust_shown` exists\n"
+            "- Unit test: guard logs but does not raise when a forbidden key is present"
+        ),
+        "slug": "security-model",
+    },
+    {
+        "title": "feat: add environment detection layer (RuntimeEnvironment enum + strategy map)",
+        "labels": ["infra", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add `quell/env/detector.py` with `RuntimeEnvironment` enum (8 types) and "
+            "`detect_environment()` + `ENVIRONMENT_STRATEGY` map that maps each env to a "
+            "container mode (testcontainers / dind / warn_skip / skip).\n\n"
+            "## Why\n"
+            "Each runtime needs a different container startup strategy. "
+            "The engine must know where it is before starting any container.\n\n"
+            "## Files\n"
+            "- `quell/env/__init__.py` (new)\n"
+            "- `quell/env/detector.py` (new)\n\n"
+            "## Acceptance Criteria\n"
+            "- All 8 environment types detected via env vars / filesystem signals\n"
+            "- K8s + NO_DOCKER return warn_skip/skip with CI setup hints\n"
+            "- Unit tests cover GITHUB_ACTIONS, LOCAL_DOCKER, KUBERNETES_POD, NO_DOCKER paths"
+        ),
+        "slug": "env-detection",
+    },
+    {
+        "title": "feat: add QuellGraph SQLite schema and incremental AST builder",
+        "labels": ["graph", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add `quell/graph/schema.sql` (full DDL: functions, classes, modules, calls, imports, "
+            "inherits, uses_model, param_types tables) and `quell/graph/builder.py` "
+            "(`QuellGraphBuilder`) with incremental sha256-based file invalidation, BFS infra-tag "
+            "propagation, and cross-file call resolution.\n\n"
+            "## Why\n"
+            "A flat per-file scanner cannot detect transitive infra dependencies. "
+            "QuellGraph sees the full call chain so the engine knows a function needs postgres "
+            "even when sqlalchemy is 3 hops away.\n\n"
+            "## Files\n"
+            "- `quell/graph/__init__.py` (new)\n"
+            "- `quell/graph/schema.sql` (new)\n"
+            "- `quell/graph/builder.py` (new)\n\n"
+            "## Acceptance Criteria\n"
+            "- Cold build on 50-file project < 5 s; incremental (3 changed files) < 500 ms\n"
+            "- `_propagate_infra_tags` BFS tested on synthetic 3-hop chain\n"
+            "- Unit test: get_user -> db.query -> Session -> sqlalchemy returns {\"postgres\"}"
+        ),
+        "slug": "quellgraph-builder",
+    },
+    {
+        "title": "feat: add QuellGraph query API (transitive tags, call chain, staleness)",
+        "labels": ["graph", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add `quell/graph/query.py` with `QuellGraph` read API: `get_transitive_infra_tags`, "
+            "`get_call_chain`, `get_pydantic_models_used`, `get_infra_dependency_path`, "
+            "`find_stale_tests`, `has_cycles_in_chain`.\n\n"
+            "## Why\n"
+            "The confidence scorer and container engine both query the graph. "
+            "They need a clean read-only API that does not touch the builder internals.\n\n"
+            "## Files\n"
+            "- `quell/graph/query.py` (new)\n\n"
+            "## Acceptance Criteria\n"
+            "- `get_infra_dependency_path` returns a human-readable shortest-path explanation\n"
+            "- `find_stale_tests` correctly identifies functions touched by changed files\n"
+            "- `has_cycles_in_chain` returns True for a synthetic cyclic call graph"
+        ),
+        "slug": "quellgraph-query",
+    },
+    {
+        "title": "feat: add import dependency registry and container specs (IMPORT_SIGNALS + CONTAINER_SPECS)",
+        "labels": ["infra", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add to `quell/infra/specs.py`: `IMPORT_SIGNALS` (import name -> infra tag), "
+            "`INFRA_TYPE_NAMES` (parameter type names like Session -> postgres), "
+            "`ContainerSpec` Pydantic model, and `CONTAINER_SPECS` registry for "
+            "postgres, redis, localstack, mongo, smtp, rabbitmq, elasticsearch.\n\n"
+            "## Why\n"
+            "The graph builder uses IMPORT_SIGNALS to tag modules. "
+            "The container engine uses CONTAINER_SPECS to know which image to start and "
+            "how to wait for it to be ready.\n\n"
+            "## Files\n"
+            "- `quell/infra/__init__.py` (new)\n"
+            "- `quell/infra/specs.py` (new)\n\n"
+            "## Acceptance Criteria\n"
+            "- All 7 container specs have image, port, wait_strategy, connection_url_template\n"
+            "- `IMPORT_SIGNALS` covers sqlalchemy, redis, boto3, pymongo, pika, smtplib, elasticsearch\n"
+            "- `ContainerSpec` validates correctly with Pydantic v2"
+        ),
+        "slug": "infra-specs",
+    },
+    {
+        "title": "feat: add container engine with session management, lockfile reuse, and phase isolation",
+        "labels": ["infra", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add `quell/infra/engine.py` (`ContainerEngine`, `ContainerSession`), "
+            "`quell/infra/lockfile.py` (keep-alive container reuse via `.quellgraph/containers.lock`), "
+            "`quell/infra/resolver.py` (DependencyProfile -> [ContainerSpec]), and "
+            "`quell/infra/fixture_gen.py` (ContainerSpec -> pytest fixture source). "
+            "Patch `quell/core/verifier.py` to inject `QUELL_TRANSACTION_ROLLBACK=true` "
+            "so Phase 1 and Phase 2 always start from the same DB state.\n\n"
+            "## Why\n"
+            "Containers are started once per run (shared across all functions), reused across "
+            "consecutive runs via the lockfile, and always destroyed on clean exit. "
+            "Phase 2 mutation must not corrupt DB state left by Phase 1.\n\n"
+            "## Files\n"
+            "- `quell/infra/engine.py`, `quell/infra/lockfile.py`, `quell/infra/resolver.py`, `quell/infra/fixture_gen.py` (new)\n"
+            "- `quell/core/verifier.py` (patch: transaction rollback env injection)\n\n"
+            "## Acceptance Criteria\n"
+            "- Orphaned containers from a previous killed run are detected and cleaned on next startup\n"
+            "- `_start_or_reuse` reads lockfile before starting a new container\n"
+            "- End-to-end: sample function with SQLAlchemy Session param reaches VERIFIED"
+        ),
+        "slug": "container-engine",
+    },
+    {
+        "title": "feat: add six-factor confidence score system with tier gating",
+        "labels": ["scoring", "enhancement"],
+        "body": (
+            "## What\n"
+            "Add `quell/scoring/confidence.py` with `ConfidenceScore` and six scoring functions: "
+            "`score_annotation_coverage` (25 pts), `score_constraint_clarity` (25 pts), "
+            "`score_dependency_clarity` (20 pts), `score_graph_coverage` (15 pts), "
+            "`score_docstring_quality` (10 pts), `score_mutation_strength` (5 pts). "
+            "Add `TIERS` map (HIGH>=85, MEDIUM>=70, LOW>=50, SKIP<50) that gates writes and CI.\n\n"
+            "## Why\n"
+            "quelltest is the only test tool that scores its own certainty before writing. "
+            "The tier system gates what enters CI (>=70) vs what is written at all (>=50).\n\n"
+            "## Files\n"
+            "- `quell/scoring/__init__.py` (new)\n"
+            "- `quell/scoring/confidence.py` (new)\n"
+            "- `quell/core/generator.py` (patch: apply confidence gate before writing)\n\n"
+            "## Acceptance Criteria\n"
+            "- Fully-typed pure function scores >= 80\n"
+            "- Unannotated function with no docstring scores <= 40\n"
+            "- Snapshot tests for known-high and known-low functions pass"
+        ),
+        "slug": "confidence-scorer",
+    },
+    {
+        "title": "feat: extend CLI with quell graph commands, --with-containers flag, and quell teardown",
+        "labels": ["dx", "enhancement"],
+        "body": (
+            "## What\n"
+            "Extend `quell/cli.py` with: `quell graph build/show/why/stale/stats` subcommands, "
+            "new `quell check` flags (`--with-containers`, `--min-confidence=N`, `--show-why`, "
+            "`--keep-containers`, `--graph-rebuild`), and `quell teardown` command that stops "
+            "and removes all quelltest-managed containers.\n\n"
+            "## Why\n"
+            "The graph and container engine need a user-facing surface. "
+            "`quell graph why <function>` explains the dependency path so users understand "
+            "why a container is being started.\n\n"
+            "## Files\n"
+            "- `quell/cli.py` (patch)\n\n"
+            "## Acceptance Criteria\n"
+            "- `quell graph build src/` runs QuellGraphBuilder and prints BuildReport\n"
+            "- `quell graph stats` prints function/class/infra/pure counts\n"
+            "- `quell teardown` reads lockfile and removes all tracked containers\n"
+            "- `--min-confidence` flag is forwarded to the confidence gate in generator"
+        ),
+        "slug": "cli-extensions",
+    },
+]
+
+numbers = []
+for i, issue in enumerate(ISSUES, 1):
+    payload = {
+        "title": issue["title"],
+        "body": issue["body"],
+        "labels": issue["labels"],
+        "assignees": [ASSIGNEE],
+    }
+    result = post("issues", payload)
+    n = result["number"]
+    numbers.append((n, issue["slug"], issue["title"]))
+    print(f"  #{n}  {issue['title'][:70]}")
+
+# Parent tracking issue
+child_links = "\n".join(f"- #{n} — {title}" for n, _, title in numbers)
+parent_body = (
+    "## v1.0 — Infrastructure-Aware Verified Testing\n\n"
+    "Tracks all spec6 work items. Closes when all child issues are merged.\n\n"
+    "### Child issues\n"
+    f"{child_links}\n\n"
+    "### Systems\n"
+    "1. **Ephemeral Container Engine** — zero-credential throwaway infra per test run\n"
+    "2. **QuellGraph** — persistent local SQLite code-intelligence graph\n"
+    "3. **Confidence Score System** — per-test certainty rating that gates writes\n\n"
+    "### Rollout\n"
+    "Week 1: QuellGraph foundation | Week 2: Confidence scorer | "
+    "Week 3: Container engine | Week 4: Polish + dogfood"
+)
+parent = post("issues", {
+    "title": "tracking: v1.0 — infrastructure-aware verified testing (spec6)",
+    "body": parent_body,
+    "labels": ["enhancement"],
+    "assignees": [ASSIGNEE],
+})
+print(f"\nParent #{parent['number']}  {parent['title']}")
+print("\nDone. All issues created in quelltest/quelltest_lib.")

--- a/tests/unit/test_infra_specs.py
+++ b/tests/unit/test_infra_specs.py
@@ -1,0 +1,93 @@
+"""Tests for quell.infra.specs — security model and registry."""
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from quell.infra.specs import (
+    CONTAINER_SPECS,
+    EPHEMERAL_CREDS,
+    FORBIDDEN_ENV_READS,
+    IMPORT_SIGNALS,
+    INFRA_TYPE_NAMES,
+    ContainerSpec,
+    _assert_no_credential_reads,
+    show_trust_message_once,
+)
+
+
+class TestForbiddenEnvGuard:
+    def test_guard_logs_forbidden_key_but_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://real/prod")
+        with caplog.at_level(logging.DEBUG, logger="quell.infra.specs"):
+            _assert_no_credential_reads()
+        assert any("DATABASE_URL" in r.message for r in caplog.records)
+
+    def test_guard_covers_all_13_forbidden_names(self) -> None:
+        assert len(FORBIDDEN_ENV_READS) == 13
+
+    def test_guard_does_not_raise_when_env_is_clean(self) -> None:
+        for key in FORBIDDEN_ENV_READS:
+            os.environ.pop(key, None)
+        _assert_no_credential_reads()  # must not raise
+
+
+class TestEphemeralCreds:
+    def test_all_five_services_present(self) -> None:
+        assert set(EPHEMERAL_CREDS) == {"postgres", "redis", "mongo", "mysql", "localstack"}
+
+    def test_postgres_creds_are_ephemeral_not_real(self) -> None:
+        pg = EPHEMERAL_CREDS["postgres"]
+        assert pg["user"] == "quell"
+        assert pg["password"] == "quell_eph"
+        assert pg["db"] == "quell_test"
+
+
+class TestContainerSpecs:
+    def test_all_seven_specs_present(self) -> None:
+        assert set(CONTAINER_SPECS) == {
+            "postgres", "redis", "localstack", "mongo", "smtp", "rabbitmq", "elasticsearch"
+        }
+
+    def test_each_spec_has_required_fields(self) -> None:
+        for name, spec in CONTAINER_SPECS.items():
+            assert isinstance(spec, ContainerSpec), name
+            assert spec.image, name
+            assert spec.port > 0, name
+            assert "{host}" in spec.connection_url_template, name
+            assert "{port}" in spec.connection_url_template, name
+
+    def test_fixture_names_all_prefixed(self) -> None:
+        for name, spec in CONTAINER_SPECS.items():
+            assert spec.fixture_name.startswith("_quell_"), name
+
+
+class TestImportSignals:
+    def test_sqlalchemy_maps_to_postgres(self) -> None:
+        assert IMPORT_SIGNALS["sqlalchemy"] == "postgres"
+
+    def test_boto3_maps_to_localstack(self) -> None:
+        assert IMPORT_SIGNALS["boto3"] == "localstack"
+
+    def test_session_type_maps_to_postgres(self) -> None:
+        assert INFRA_TYPE_NAMES["Session"] == "postgres"
+
+
+class TestTrustMessage:
+    def test_show_trust_message_once_creates_flag(self, tmp_path: pytest.TempPathFactory) -> None:
+        import quell.infra.specs as specs_mod
+        original = specs_mod._TRUST_FLAG
+        flag = tmp_path / "trust_shown"  # type: ignore[operator]
+        specs_mod._TRUST_FLAG = flag  # type: ignore[assignment]
+        try:
+            assert not flag.exists()
+            show_trust_message_once()
+            assert flag.exists()
+            # second call must not raise
+            show_trust_message_once()
+        finally:
+            specs_mod._TRUST_FLAG = original


### PR DESCRIPTION
Closes quelltest/quelltest_lib#11

## What
Adds `EPHEMERAL_CREDS`, `FORBIDDEN_ENV_READS`, `_assert_no_credential_reads()`, and `show_trust_message_once()` to `quell/infra/specs.py`. Guard is called at verifier module load.

## Tests
12 unit tests green covering guard logging, ephemeral creds, container specs, import signals, and trust message flag.