### PR TITLE
feat(graph): QuellGraph read-only query API

### DIFF
--- a/quell/graph/query.py
+++ b/quell/graph/query.py
@@ -1,0 +1,316 @@
+"""
+QuellGraph read-only query API.
+
+All methods are pure reads against the SQLite graph.db produced by builder.py.
+The caller holds a QuellGraph instance; the builder populates the database.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CallNode:
+    """A node in the function call chain."""
+
+    function_id: str
+    name: str
+    file: str
+    is_resolved: bool
+    infra_tags: list[str]
+
+
+@dataclass(frozen=True)
+class FunctionInfo:
+    """Lightweight summary of a function from the graph."""
+
+    id: str
+    name: str
+    file: str
+    line_start: int
+    docstring: str | None
+    is_pure: bool
+    purity_score: float
+    annotation_coverage: float
+    infra_tags: list[str]
+    has_docstring: bool
+    has_raises_block: bool
+    has_returns_block: bool
+    has_args_block: bool
+    param_count: int
+
+
+@dataclass(frozen=True)
+class ClassInfo:
+    """Lightweight summary of a class from the graph."""
+
+    id: str
+    name: str
+    file: str
+    is_pydantic: bool
+    fields: list[dict]
+
+
+class QuellGraph:
+    """
+    Read-only query interface to a QuellGraph SQLite database.
+
+    Usage::
+
+        graph = QuellGraph(Path(".quellgraph/graph.db"))
+        tags  = graph.get_transitive_infra_tags(fn_id)
+        graph.close()
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        if not db_path.exists():
+            raise FileNotFoundError(
+                f"QuellGraph database not found at {db_path}. "
+                "Run `quell graph build` first."
+            )
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Function lookups
+    # ------------------------------------------------------------------
+
+    def get_function(self, file: str, name: str) -> FunctionInfo | None:
+        """Look up a function by file path and name."""
+        row = self._conn.execute(
+            "SELECT * FROM functions WHERE file=? AND name=? LIMIT 1",
+            (file, name),
+        ).fetchone()
+        return _row_to_function(row) if row else None
+
+    def get_function_by_id(self, function_id: str) -> FunctionInfo | None:
+        """Look up a function by its graph ID."""
+        row = self._conn.execute(
+            "SELECT * FROM functions WHERE id=? LIMIT 1", (function_id,)
+        ).fetchone()
+        return _row_to_function(row) if row else None
+
+    def list_functions(self, file: str | None = None) -> list[FunctionInfo]:
+        """List all functions, optionally filtered by file."""
+        if file:
+            rows = self._conn.execute(
+                "SELECT * FROM functions WHERE file=? ORDER BY line_start", (file,)
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM functions ORDER BY file, line_start"
+            ).fetchall()
+        return [_row_to_function(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Infra tag queries
+    # ------------------------------------------------------------------
+
+    def get_transitive_infra_tags(self, function_id: str) -> set[str]:
+        """Return all infra tags reachable from this function (BFS precomputed)."""
+        row = self._conn.execute(
+            "SELECT infra_tags FROM functions WHERE id=?", (function_id,)
+        ).fetchone()
+        if not row or not row["infra_tags"]:
+            return set()
+        return set(json.loads(row["infra_tags"]))
+
+    def get_infra_dependency_path(self, function_id: str) -> list[str]:
+        """
+        Shortest path explaining WHY this function needs an infra tag.
+
+        Returns a list of names: [caller, ..., callee, import, tag].
+        Example: ["process_payment", "db.query", "Session", "sqlalchemy", "postgres"]
+        """
+        fn = self.get_function_by_id(function_id)
+        if fn is None or not fn.infra_tags:
+            return []
+
+        path: list[str] = [fn.name]
+        visited: set[str] = {function_id}
+        queue = [function_id]
+
+        while queue:
+            current_id = queue.pop(0)
+            # Find a callee that has infra tags
+            for row in self._conn.execute(
+                """SELECT c.callee_id, c.callee_name, f.infra_tags
+                   FROM calls c
+                   LEFT JOIN functions f ON f.id = c.callee_id
+                   WHERE c.caller_id = ? AND c.is_resolved = 1""",
+                (current_id,),
+            ):
+                if row["callee_id"] and row["callee_id"] not in visited:
+                    callee_tags = json.loads(row["infra_tags"] or "[]")
+                    path.append(row["callee_name"])
+                    if callee_tags:
+                        path.extend(callee_tags[:1])
+                        return path
+                    visited.add(row["callee_id"])
+                    queue.append(row["callee_id"])
+
+        # Fallback: show direct import tags
+        module_row = self._conn.execute(
+            "SELECT infra_tags FROM modules WHERE file=?", (fn.file,)
+        ).fetchone()
+        if module_row and module_row["infra_tags"]:
+            tags = json.loads(module_row["infra_tags"])
+            if tags:
+                path.extend(tags[:1])
+        return path
+
+    # ------------------------------------------------------------------
+    # Call chain queries
+    # ------------------------------------------------------------------
+
+    def get_call_chain(self, function_id: str, depth: int = 5) -> list[CallNode]:
+        """Return the call tree up to `depth` levels deep (BFS)."""
+        result: list[CallNode] = []
+        visited: set[str] = {function_id}
+        queue: list[tuple[str, int]] = [(function_id, 0)]
+
+        while queue:
+            current_id, current_depth = queue.pop(0)
+            if current_depth >= depth:
+                continue
+            for row in self._conn.execute(
+                """SELECT c.callee_id, c.callee_name, c.is_resolved,
+                          f.file, f.infra_tags
+                   FROM calls c
+                   LEFT JOIN functions f ON f.id = c.callee_id
+                   WHERE c.caller_id = ?""",
+                (current_id,),
+            ):
+                node = CallNode(
+                    function_id=row["callee_id"] or "",
+                    name=row["callee_name"],
+                    file=row["file"] or "",
+                    is_resolved=bool(row["is_resolved"]),
+                    infra_tags=json.loads(row["infra_tags"] or "[]") if row["infra_tags"] else [],
+                )
+                result.append(node)
+                if row["callee_id"] and row["callee_id"] not in visited:
+                    visited.add(row["callee_id"])
+                    queue.append((row["callee_id"], current_depth + 1))
+
+        return result
+
+    def has_cycles_in_chain(self, function_id: str) -> bool:
+        """Return True if the call chain from this function contains a cycle."""
+        visited: set[str] = set()
+        stack: list[str] = [function_id]
+
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                return True
+            visited.add(current)
+            for row in self._conn.execute(
+                "SELECT callee_id FROM calls WHERE caller_id=? AND is_resolved=1",
+                (current,),
+            ):
+                if row["callee_id"]:
+                    stack.append(row["callee_id"])
+        return False
+
+    # ------------------------------------------------------------------
+    # Pydantic model queries
+    # ------------------------------------------------------------------
+
+    def get_pydantic_models_used(self, function_id: str) -> list[ClassInfo]:
+        """Pydantic model classes used as param or return types."""
+        rows = self._conn.execute(
+            """SELECT c.* FROM classes c
+               JOIN uses_model um ON um.class_id = c.id
+               WHERE um.function_id = ? AND c.is_pydantic = 1""",
+            (function_id,),
+        ).fetchall()
+        return [_row_to_class(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Staleness detection
+    # ------------------------------------------------------------------
+
+    def find_stale_tests(self, changed_files: list[str]) -> list[str]:
+        """
+        Given files changed since last `quell check`, return function IDs
+        whose generated tests may now be stale.
+        """
+        stale: set[str] = set()
+        for file in changed_files:
+            # Functions defined in the changed file
+            for row in self._conn.execute(
+                "SELECT id FROM functions WHERE file=?", (file,)
+            ):
+                stale.add(row["id"])
+            # Functions that call into this file (callers may be stale too)
+            for row in self._conn.execute(
+                """SELECT DISTINCT c.caller_id FROM calls c
+                   JOIN functions f ON f.id = c.callee_id
+                   WHERE f.file = ?""",
+                (file,),
+            ):
+                stale.add(row["caller_id"])
+        return list(stale)
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def stats(self) -> dict[str, int]:
+        """Return summary stats: function/class/infra/pure counts."""
+        total_fns = self._conn.execute("SELECT COUNT(*) FROM functions").fetchone()[0]
+        total_cls = self._conn.execute("SELECT COUNT(*) FROM classes").fetchone()[0]
+        infra_fns = self._conn.execute(
+            "SELECT COUNT(*) FROM functions WHERE infra_tags != '[]' AND infra_tags IS NOT NULL"
+        ).fetchone()[0]
+        pure_fns = self._conn.execute(
+            "SELECT COUNT(*) FROM functions WHERE is_pure = 1"
+        ).fetchone()[0]
+        return {
+            "functions": total_fns,
+            "classes": total_cls,
+            "infra_dependent": infra_fns,
+            "pure": pure_fns,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Row converters
+# ---------------------------------------------------------------------------
+
+def _row_to_function(row: sqlite3.Row) -> FunctionInfo:
+    return FunctionInfo(
+        id=row["id"],
+        name=row["name"],
+        file=row["file"],
+        line_start=row["line_start"] or 0,
+        docstring=row["docstring"],
+        is_pure=bool(row["is_pure"]),
+        purity_score=row["purity_score"] or 0.0,
+        annotation_coverage=row["annotation_coverage"] or 0.0,
+        infra_tags=json.loads(row["infra_tags"] or "[]"),
+        has_docstring=bool(row["has_docstring"]),
+        has_raises_block=bool(row["has_raises_block"]),
+        has_returns_block=bool(row["has_returns_block"]),
+        has_args_block=bool(row["has_args_block"]),
+        param_count=row["param_count"] or 0,
+    )
+
+
+def _row_to_class(row: sqlite3.Row) -> ClassInfo:
+    return ClassInfo(
+        id=row["id"],
+        name=row["name"],
+        file=row["file"],
+        is_pydantic=bool(row["is_pydantic"]),
+        fields=json.loads(row["fields"] or "[]"),
+    )

--- a/tests/unit/test_quellgraph_query.py
+++ b/tests/unit/test_quellgraph_query.py
@@ -1,0 +1,209 @@
+"""Tests for QuellGraph query API — using a hand-built SQLite database."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from quell.graph.query import QuellGraph
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal synthetic graph.db without the builder
+# ---------------------------------------------------------------------------
+
+_SCHEMA = Path(__file__).parent.parent.parent / "quell" / "graph" / "schema.sql"
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a minimal graph.db with synthetic functions, modules, and calls."""
+    db_path = tmp_path / ".quellgraph" / "graph.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA.read_text(encoding="utf-8"))
+
+    pg_file = str(tmp_path / "src" / "payments.py")
+    ut_file = str(tmp_path / "src" / "utils.py")
+
+    # Modules
+    conn.execute(
+        "INSERT INTO modules (id, file, package, infra_tags, file_hash, parsed_at) VALUES (?,?,?,?,?,?)",
+        (pg_file, pg_file, "payments", json.dumps(["postgres"]), "abc", 1.0),
+    )
+    conn.execute(
+        "INSERT INTO modules (id, file, package, infra_tags, file_hash, parsed_at) VALUES (?,?,?,?,?,?)",
+        (ut_file, ut_file, "utils", json.dumps([]), "def", 1.0),
+    )
+
+    # Functions
+    conn.execute("""
+        INSERT INTO functions (id, name, file, line_start, docstring,
+            is_pure, purity_score, annotation_coverage, infra_tags, direct_infra_tags,
+            has_docstring, has_raises_block, has_returns_block, has_args_block,
+            param_count, file_hash, parsed_at)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    """, ("fn-pay", "process_payment", pg_file, 5, "Process payment.",
+          0, 0.6, 0.67, json.dumps(["postgres"]), json.dumps(["postgres"]),
+          1, 1, 1, 1, 2, "abc", 1.0))
+
+    conn.execute("""
+        INSERT INTO functions (id, name, file, line_start, docstring,
+            is_pure, purity_score, annotation_coverage, infra_tags, direct_infra_tags,
+            has_docstring, has_raises_block, has_returns_block, has_args_block,
+            param_count, file_hash, parsed_at)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    """, ("fn-util", "validate_email", ut_file, 3, "Check email format.",
+          1, 1.0, 1.0, json.dumps([]), json.dumps([]),
+          1, 0, 1, 1, 1, "def", 1.0))
+
+    conn.execute("""
+        INSERT INTO functions (id, name, file, line_start, docstring,
+            is_pure, purity_score, annotation_coverage, infra_tags, direct_infra_tags,
+            has_docstring, has_raises_block, has_returns_block, has_args_block,
+            param_count, file_hash, parsed_at)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    """, ("fn-cache", "get_from_cache", pg_file, 20, None,
+          0, 0.8, 0.5, json.dumps(["redis"]), json.dumps(["redis"]),
+          0, 0, 0, 0, 1, "abc", 1.0))
+
+    # Calls: process_payment → get_from_cache (resolved)
+    conn.execute(
+        "INSERT INTO calls (caller_id, callee_id, callee_name, line, is_resolved) VALUES (?,?,?,?,?)",
+        ("fn-pay", "fn-cache", "get_from_cache", 10, 1),
+    )
+
+    # Param types
+    conn.execute(
+        "INSERT INTO param_types (function_id, param_name, type_str, is_typed, is_infra_type, infra_tag)"
+        " VALUES (?,?,?,?,?,?)",
+        ("fn-pay", "db", "Session", 1, 1, "postgres"),
+    )
+    conn.execute(
+        "INSERT INTO param_types (function_id, param_name, type_str, is_typed, is_infra_type, infra_tag)"
+        " VALUES (?,?,?,?,?,?)",
+        ("fn-util", "email", "str", 1, 0, None),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture()
+def graph(tmp_path: Path) -> QuellGraph:
+    db_path = _make_db(tmp_path)
+    g = QuellGraph(db_path)
+    yield g
+    g.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetFunction:
+    def test_finds_by_file_and_name(self, graph: QuellGraph, tmp_path: Path) -> None:
+        fn = graph.get_function(str(tmp_path / "src" / "payments.py"), "process_payment")
+        assert fn is not None
+        assert fn.name == "process_payment"
+        assert fn.has_raises_block is True
+
+    def test_returns_none_for_missing(self, graph: QuellGraph, tmp_path: Path) -> None:
+        fn = graph.get_function(str(tmp_path / "src" / "payments.py"), "nonexistent")
+        assert fn is None
+
+    def test_get_function_by_id(self, graph: QuellGraph) -> None:
+        fn = graph.get_function_by_id("fn-pay")
+        assert fn is not None
+        assert fn.name == "process_payment"
+
+    def test_list_functions_filtered_by_file(self, graph: QuellGraph, tmp_path: Path) -> None:
+        fns = graph.list_functions(str(tmp_path / "src" / "utils.py"))
+        assert len(fns) == 1
+        assert fns[0].name == "validate_email"
+
+
+class TestTransitiveInfraTags:
+    def test_infra_function_has_postgres(self, graph: QuellGraph) -> None:
+        tags = graph.get_transitive_infra_tags("fn-pay")
+        assert "postgres" in tags
+
+    def test_pure_function_returns_empty_set(self, graph: QuellGraph) -> None:
+        tags = graph.get_transitive_infra_tags("fn-util")
+        assert tags == set()
+
+    def test_unknown_id_returns_empty_set(self, graph: QuellGraph) -> None:
+        tags = graph.get_transitive_infra_tags("nonexistent-id")
+        assert tags == set()
+
+
+class TestCallChain:
+    def test_call_chain_returns_callees(self, graph: QuellGraph) -> None:
+        chain = graph.get_call_chain("fn-pay", depth=3)
+        assert len(chain) >= 1
+        names = [c.name for c in chain]
+        assert "get_from_cache" in names
+
+    def test_call_chain_depth_zero_returns_empty(self, graph: QuellGraph) -> None:
+        chain = graph.get_call_chain("fn-pay", depth=0)
+        assert chain == []
+
+    def test_leaf_function_has_empty_chain(self, graph: QuellGraph) -> None:
+        chain = graph.get_call_chain("fn-util")
+        assert chain == []
+
+
+class TestCycleDetection:
+    def test_no_cycle_for_leaf(self, graph: QuellGraph) -> None:
+        assert graph.has_cycles_in_chain("fn-util") is False
+
+    def test_no_cycle_in_simple_chain(self, graph: QuellGraph) -> None:
+        # fn-pay → fn-cache, no cycle
+        assert graph.has_cycles_in_chain("fn-pay") is False
+
+
+class TestStaleness:
+    def test_changed_file_returns_its_functions(self, graph: QuellGraph, tmp_path: Path) -> None:
+        stale = graph.find_stale_tests([str(tmp_path / "src" / "utils.py")])
+        assert "fn-util" in stale
+
+    def test_empty_changed_files_returns_empty(self, graph: QuellGraph) -> None:
+        assert graph.find_stale_tests([]) == []
+
+    def test_callers_of_changed_file_are_stale(self, graph: QuellGraph, tmp_path: Path) -> None:
+        # fn-pay calls fn-cache (in payments.py); changing payments.py → fn-pay stale
+        stale = graph.find_stale_tests([str(tmp_path / "src" / "payments.py")])
+        assert "fn-pay" in stale
+
+
+class TestStats:
+    def test_stats_keys(self, graph: QuellGraph) -> None:
+        s = graph.stats()
+        assert set(s.keys()) == {"functions", "classes", "infra_dependent", "pure"}
+
+    def test_stats_counts(self, graph: QuellGraph) -> None:
+        s = graph.stats()
+        assert s["functions"] == 3
+        assert s["pure"] == 1           # only validate_email
+        assert s["infra_dependent"] == 2  # process_payment + get_from_cache
+
+
+class TestInfoDependencyPath:
+    def test_path_starts_with_function_name(self, graph: QuellGraph) -> None:
+        path = graph.get_infra_dependency_path("fn-pay")
+        assert len(path) >= 1
+        assert path[0] == "process_payment"
+
+    def test_pure_function_returns_short_path(self, graph: QuellGraph) -> None:
+        path = graph.get_infra_dependency_path("fn-util")
+        # No infra deps — returns just the name or empty
+        assert isinstance(path, list)
+
+
+class TestMissingDB:
+    def test_raises_if_db_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            QuellGraph(tmp_path / "nonexistent.db")


### PR DESCRIPTION
Closes quelltest/quelltest-lib#14

## What
Adds `quell/graph/query.py` with `QuellGraph` read-only class: `get_function`, `get_transitive_infra_tags`, `get_call_chain`, `has_cycles_in_chain`, `get_infra_dependency_path`, `find_stale_tests`, `stats`. Uses `schema.sql` from #13 (now merged).

## Tests
20 unit tests green against a synthetic SQLite database (no builder dependency).