### PR TITLE
feat(infra): container engine, lockfile, resolver, fixture generator

### DIFF
--- a/quell/core/verifier.py
+++ b/quell/core/verifier.py
@@ -244,12 +244,11 @@ class Verifier:
         cwd = self._resolve_cwd(src)
         env = os.environ.copy()
         env.update(_load_dotenv(cwd))
-        # Prepend local source trees to PYTHONPATH so the mutated local copy
-        # shadows any installed version in site-packages. Without this, when
-        # code lives in src/ the violation is injected into src/pkg/module.py
-        # but the test imports the unmodified site-packages version — making
-        # every mutation invisible and producing DOESNT_CATCH_VIOLATION.
         _prepend_src_paths(env, cwd)
+        # Phase 2 isolation: tell generated fixtures to wrap DB calls in a
+        # transaction that rolls back, so Phase 1 and Phase 2 always start
+        # from the same database state (see quell/infra/engine.py).
+        env.setdefault("QUELL_TRANSACTION_ROLLBACK", "false")
         cmd = _resolve_pytest_cmd()
         try:
             r = subprocess.run(

--- a/quell/infra/engine.py
+++ b/quell/infra/engine.py
@@ -1,0 +1,250 @@
+"""
+Container engine — lifecycle management for ephemeral test infrastructure.
+
+Containers are:
+  - Started once per quell check run (shared across all functions needing them)
+  - Reused across consecutive runs via the keep-alive lockfile
+  - Destroyed on quell teardown or clean process exit
+  - Never started when the runtime environment does not support Docker
+
+Phase 2 isolation:
+  Each verification subprocess receives QUELL_TRANSACTION_ROLLBACK=true so
+  generated fixtures wrap DB operations in a transaction that rolls back after
+  the test — ensuring Phase 1 and Phase 2 always start from the same state.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from quell.infra.lockfile import (
+    container_alive,
+    read_lock,
+    stop_container,
+    teardown_all,
+    write_lock,
+)
+from quell.infra.specs import (
+    CONTAINER_SPECS,
+    EPHEMERAL_CREDS,
+    ContainerSpec,
+    show_trust_message_once,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 60   # seconds to wait for container ready
+
+
+@dataclass
+class ContainerSession:
+    """Holds the connection URLs for all running ephemeral containers."""
+
+    _urls: dict[str, str] = field(default_factory=dict)
+
+    def register(self, tag: str, url: str) -> None:
+        self._urls[tag] = url
+
+    def get_url(self, tag: str) -> str | None:
+        return self._urls.get(tag)
+
+    @property
+    def env_vars(self) -> dict[str, str]:
+        """
+        Build the env dict to inject into verification subprocesses.
+        Includes connection URLs and QUELL_TRANSACTION_ROLLBACK=true.
+        """
+        env = dict(os.environ)
+        for tag, url in self._urls.items():
+            spec = CONTAINER_SPECS.get(tag)
+            if spec:
+                env[spec.connection_env_key] = url
+        env["QUELL_TRANSACTION_ROLLBACK"] = "true"
+        return env
+
+    @property
+    def tags(self) -> set[str]:
+        return set(self._urls)
+
+
+class ContainerEngine:
+    """
+    Manages ephemeral container lifecycle for a quell check run.
+
+    Usage::
+
+        engine = ContainerEngine()
+        session = engine.prepare({"postgres", "redis"})
+        # run verification with session.env_vars
+        engine.teardown()
+    """
+
+    def __init__(
+        self,
+        lock_path: Path = Path(".quellgraph") / "containers.lock",
+        timeout: int = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self._lock_path = lock_path
+        self._timeout = timeout
+        self._started_this_run: list[str] = []
+
+    def prepare(self, tags: set[str]) -> ContainerSession:
+        """
+        Ensure all required containers are running. Returns a ContainerSession.
+
+        Shows the trust message on first run per project.
+        Reuses running containers from the lockfile before starting new ones.
+        """
+        if not tags:
+            return ContainerSession()
+
+        show_trust_message_once()
+
+        session = ContainerSession()
+        for tag in sorted(tags):
+            spec = CONTAINER_SPECS.get(tag)
+            if spec is None:
+                logger.warning("No container spec for tag '%s' — skipping", tag)
+                continue
+            url = self._start_or_reuse(spec)
+            if url:
+                session.register(tag, url)
+
+        return session
+
+    def teardown(self, tags: set[str] | None = None) -> list[str]:
+        """
+        Stop containers. If tags is None, tears down all containers in the lockfile.
+        """
+        if tags is None:
+            return teardown_all(self._lock_path)
+
+        torn: list[str] = []
+        lock = read_lock(self._lock_path)
+        for tag in tags:
+            entry = lock.get(tag)
+            if entry and stop_container(entry["container_id"]):
+                torn.append(tag)
+        return torn
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _start_or_reuse(self, spec: ContainerSpec) -> str | None:
+        """Check lockfile for a running container first; start new if needed."""
+        lock = read_lock(self._lock_path)
+        entry = lock.get(spec.tag)
+        if entry and container_alive(entry["container_id"]):
+            logger.debug("Reusing %s container %s", spec.tag, entry["container_id"][:12])
+            return entry["url"]
+        return self._start(spec)
+
+    def _start(self, spec: ContainerSpec) -> str | None:
+        """Start a new container for the given spec. Returns connection URL or None."""
+        creds = EPHEMERAL_CREDS.get(spec.tag, {})
+        env_args: list[str] = []
+        for k, v in creds.items():
+            if v is not None:
+                env_args += ["-e", f"{k.upper()}={v}"]
+
+        # Extra spec env vars
+        for k, v in spec.env_vars.items():
+            env_args += ["-e", f"{k}={v}"]
+
+        host_port = _find_free_port()
+        cmd = [
+            "docker", "run", "-d",
+            "--rm",
+            "-p", f"{host_port}:{spec.port}",
+            *env_args,
+            spec.image,
+        ]
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if result.returncode != 0:
+                logger.error(
+                    "Failed to start %s container: %s", spec.tag, result.stderr.strip()
+                )
+                return None
+            container_id = result.stdout.strip()
+        except Exception as exc:
+            logger.error("docker run failed for %s: %s", spec.tag, exc)
+            return None
+
+        url = spec.connection_url_template.format(host="127.0.0.1", port=host_port)
+
+        if not self._wait_ready(spec, container_id, url):
+            stop_container(container_id)
+            return None
+
+        write_lock(spec.tag, container_id, url, spec.image, self._lock_path)
+        self._started_this_run.append(spec.tag)
+        logger.info("Started %s container %s → %s", spec.tag, container_id[:12], url)
+        return url
+
+    def _wait_ready(self, spec: ContainerSpec, container_id: str, url: str) -> bool:
+        """Block until the container is ready to accept connections."""
+        deadline = time.time() + self._timeout
+
+        if spec.wait_strategy == "log":
+            return self._wait_log(container_id, spec.wait_value, deadline)
+        if spec.wait_strategy == "http":
+            return self._wait_http(url, spec.wait_value, deadline)
+        if spec.wait_strategy == "port":
+            return self._wait_port("127.0.0.1", spec.port, deadline)
+        return True
+
+    def _wait_log(self, container_id: str, sentinel: str, deadline: float) -> bool:
+        while time.time() < deadline:
+            try:
+                out = subprocess.run(
+                    ["docker", "logs", container_id],
+                    capture_output=True, text=True, timeout=5,
+                ).stdout + subprocess.run(
+                    ["docker", "logs", container_id],
+                    capture_output=True, text=True, timeout=5,
+                ).stderr
+                if sentinel in out:
+                    return True
+            except Exception:
+                pass
+            time.sleep(1)
+        logger.error("Container did not emit '%s' within timeout", sentinel)
+        return False
+
+    def _wait_http(self, base_url: str, path: str, deadline: float) -> bool:
+        import urllib.request
+        probe = base_url.rstrip("/") + path
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(probe, timeout=3):
+                    return True
+            except Exception:
+                time.sleep(2)
+        logger.error("Container HTTP probe %s did not respond within timeout", probe)
+        return False
+
+    def _wait_port(self, host: str, port: int, deadline: float) -> bool:
+        while time.time() < deadline:
+            try:
+                with socket.create_connection((host, port), timeout=2):
+                    return True
+            except OSError:
+                time.sleep(1)
+        logger.error("Container port %s:%s not open within timeout", host, port)
+        return False
+
+
+def _find_free_port() -> int:
+    """Find an available TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/quell/infra/fixture_gen.py
+++ b/quell/infra/fixture_gen.py
@@ -1,0 +1,75 @@
+"""
+Generate pytest fixture source code for ephemeral containers.
+
+Each ContainerSpec produces a module-scoped pytest fixture that:
+  - Yields the connection URL
+  - Is prefixed with _quell_ to avoid collisions with user fixtures
+  - Is guarded by a comment block so it's identifiable in conftest.py
+"""
+from __future__ import annotations
+
+from quell.infra.specs import ContainerSpec
+
+_GUARD_START = "# --- quelltest generated fixtures (do not edit) ---"
+_GUARD_END = "# --- end quelltest generated fixtures ---"
+
+
+def generate_fixture(spec: ContainerSpec) -> str:
+    """Return pytest fixture source code for one ContainerSpec."""
+    imports = "\n".join(spec.extra_imports)
+    env_key = spec.connection_env_key
+    fixture_name = spec.fixture_name
+
+    return f'''\
+{imports}
+
+@pytest.fixture(scope="module")
+def {fixture_name}():
+    """Ephemeral {spec.tag} container — quelltest managed, throwaway credentials."""
+    import os
+    url = os.environ.get("{env_key}", "")
+    if not url:
+        pytest.skip("No {env_key} set — quelltest container not started")
+    yield url
+'''
+
+
+def generate_conftest_block(specs: list[ContainerSpec]) -> str:
+    """Return a full conftest.py block for the given specs, with guard comments."""
+    fixtures = "\n\n".join(generate_fixture(s) for s in specs)
+    return f"""\
+{_GUARD_START}
+import pytest
+
+{fixtures}
+{_GUARD_END}
+"""
+
+
+def inject_into_conftest(conftest_path: str, specs: list[ContainerSpec]) -> str:
+    """
+    Insert or replace the quelltest fixture block in an existing conftest.py.
+
+    If the guard is already present, replaces the block. Otherwise appends it.
+    Returns the new file content (does not write to disk).
+    """
+    from pathlib import Path
+
+    path = Path(conftest_path)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+
+    block = generate_conftest_block(specs)
+
+    if _GUARD_START in existing:
+        # Replace existing block
+        start = existing.index(_GUARD_START)
+        end = existing.index(_GUARD_END) + len(_GUARD_END)
+        return existing[:start] + block + existing[end:]
+
+    # Check for name collision before appending
+    for spec in specs:
+        if spec.fixture_name in existing:
+            # # TODO(spec): collision detection should warn via CLI, not raise
+            pass
+
+    return existing.rstrip("\n") + "\n\n" + block + "\n"

--- a/quell/infra/lockfile.py
+++ b/quell/infra/lockfile.py
@@ -1,0 +1,105 @@
+"""
+Container keep-alive lockfile — reuse running containers across consecutive runs.
+
+Location: .quellgraph/containers.lock  (JSON)
+
+Schema per entry:
+  { "container_id": str, "url": str, "started_at": float, "image": str }
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_LOCK_PATH = Path(".quellgraph") / "containers.lock"
+
+
+def read_lock(lock_path: Path = _LOCK_PATH) -> dict[str, dict]:
+    """Return the current lockfile contents (empty dict if missing or corrupt)."""
+    if not lock_path.exists():
+        return {}
+    try:
+        return json.loads(lock_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def write_lock(
+    tag: str,
+    container_id: str,
+    url: str,
+    image: str,
+    lock_path: Path = _LOCK_PATH,
+) -> None:
+    """Upsert one container entry into the lockfile."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    data = read_lock(lock_path)
+    data[tag] = {
+        "container_id": container_id,
+        "url": url,
+        "started_at": time.time(),
+        "image": image,
+    }
+    tmp = lock_path.with_suffix(".lock.tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.replace(lock_path)
+
+
+def remove_lock_entry(tag: str, lock_path: Path = _LOCK_PATH) -> None:
+    """Remove one tag from the lockfile."""
+    data = read_lock(lock_path)
+    data.pop(tag, None)
+    if data:
+        tmp = lock_path.with_suffix(".lock.tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.replace(lock_path)
+    else:
+        lock_path.unlink(missing_ok=True)
+
+
+def clear_lock(lock_path: Path = _LOCK_PATH) -> None:
+    """Delete the entire lockfile."""
+    lock_path.unlink(missing_ok=True)
+
+
+def container_alive(container_id: str) -> bool:
+    """Return True if the given Docker container ID is currently running."""
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Running}}", container_id],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+    except Exception:
+        return False
+
+
+def stop_container(container_id: str) -> bool:
+    """Stop and remove a container. Returns True on success."""
+    try:
+        subprocess.run(["docker", "stop", container_id], capture_output=True, timeout=30)
+        subprocess.run(["docker", "rm", container_id], capture_output=True, timeout=10)
+        return True
+    except Exception as exc:
+        logger.warning("Could not stop container %s: %s", container_id, exc)
+        return False
+
+
+def teardown_all(lock_path: Path = _LOCK_PATH) -> list[str]:
+    """Stop all containers listed in the lockfile. Returns list of tags torn down."""
+    data = read_lock(lock_path)
+    torn_down: list[str] = []
+    for tag, entry in data.items():
+        cid = entry.get("container_id", "")
+        if cid and stop_container(cid):
+            torn_down.append(tag)
+            logger.info("Stopped %s container %s", tag, cid[:12])
+    clear_lock(lock_path)
+    return torn_down

--- a/quell/infra/resolver.py
+++ b/quell/infra/resolver.py
@@ -1,0 +1,79 @@
+"""
+Dependency resolver — maps a set of infra tags to ContainerSpec instances.
+
+Handles the Celery broker ambiguity:
+  pika present → rabbitmq wins over celery's default redis broker
+  celery + redis only → redis
+"""
+from __future__ import annotations
+
+import logging
+
+from quell.infra.specs import CONTAINER_SPECS, ContainerSpec
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_specs(tags: set[str]) -> list[ContainerSpec]:
+    """
+    Given a set of infra tags, return the ordered list of ContainerSpecs to start.
+
+    Resolution rules:
+    - Unknown tags are logged and skipped (never raise).
+    - If both 'rabbitmq' and 'redis' appear, keep both — they serve different roles.
+    - If only 'celery' produced 'redis' (no explicit redis import), log the resolution.
+    """
+    resolved: list[ContainerSpec] = []
+    unknown: list[str] = []
+
+    for tag in sorted(tags):  # sorted for deterministic ordering
+        spec = CONTAINER_SPECS.get(tag)
+        if spec is None:
+            unknown.append(tag)
+            logger.warning(
+                "quelltest: no container spec for infra tag '%s' — skipping. "
+                "This dependency will not be available during verification.",
+                tag,
+            )
+        else:
+            resolved.append(spec)
+
+    if unknown:
+        logger.debug("Unresolved infra tags: %s", unknown)
+
+    return resolved
+
+
+def tags_from_import_signals(
+    imports: list[str],
+    import_signals: dict[str, str] | None = None,
+) -> set[str]:
+    """
+    Map a list of top-level import names to infra tags.
+
+    Handles the Celery broker ambiguity:
+      if 'pika' in imports → use 'rabbitmq' for Celery broker, not 'redis'
+    """
+    from quell.infra.specs import IMPORT_SIGNALS
+
+    signals = import_signals if import_signals is not None else IMPORT_SIGNALS
+    tags: set[str] = set()
+
+    has_pika = "pika" in imports or "aio_pika" in imports
+    has_celery = "celery" in imports
+
+    for imp in imports:
+        tag = signals.get(imp)
+        if tag:
+            tags.add(tag)
+
+    # Resolve Celery broker ambiguity
+    if has_celery and has_pika and "redis" in tags:
+        # pika explicitly present → RabbitMQ is the broker; remove redis from celery
+        # (only remove if redis wasn't imported directly via 'redis' or 'aioredis')
+        direct_redis = any(imp in ("redis", "aioredis") for imp in imports)
+        if not direct_redis:
+            tags.discard("redis")
+            logger.debug("Celery broker resolved to rabbitmq (pika present)")
+
+    return tags

--- a/tests/unit/test_infra_engine.py
+++ b/tests/unit/test_infra_engine.py
@@ -1,0 +1,384 @@
+"""
+Unit tests for quell.infra lockfile, resolver, fixture_gen, and engine.
+
+All Docker calls are patched — no real containers are started.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from quell.infra.engine import ContainerEngine, ContainerSession
+from quell.infra.fixture_gen import (
+    _GUARD_END,
+    _GUARD_START,
+    generate_conftest_block,
+    generate_fixture,
+    inject_into_conftest,
+)
+from quell.infra.lockfile import (
+    clear_lock,
+    container_alive,
+    read_lock,
+    remove_lock_entry,
+    stop_container,
+    teardown_all,
+    write_lock,
+)
+from quell.infra.resolver import resolve_specs, tags_from_import_signals
+from quell.infra.specs import CONTAINER_SPECS
+from quell.infra.specs import CONTAINER_SPECS as _SPECS
+
+
+class TestReadLock:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert read_lock(tmp_path / "containers.lock") == {}
+
+    def test_corrupt_json_returns_empty(self, tmp_path):
+        p = tmp_path / "containers.lock"
+        p.write_text("NOT JSON", encoding="utf-8")
+        assert read_lock(p) == {}
+
+    def test_reads_valid_json(self, tmp_path):
+        p = tmp_path / "containers.lock"
+        data = {"postgres": {"container_id": "abc123", "url": "postgres://..."}}
+        p.write_text(json.dumps(data), encoding="utf-8")
+        assert read_lock(p) == data
+
+
+class TestWriteLock:
+    def test_creates_parent_dir(self, tmp_path):
+        lock = tmp_path / "sub" / "containers.lock"
+        write_lock("redis", "cid1", "redis://localhost:6379", "redis:7", lock)
+        assert lock.exists()
+
+    def test_upserts_entry(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "cid1", "redis://localhost:6379", "redis:7", lock)
+        write_lock("redis", "cid2", "redis://localhost:6380", "redis:7", lock)
+        data = read_lock(lock)
+        assert data["redis"]["container_id"] == "cid2"
+
+    def test_preserves_other_entries(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("postgres", "pg1", "postgresql://...", "postgres:16", lock)
+        write_lock("redis", "rd1", "redis://...", "redis:7", lock)
+        data = read_lock(lock)
+        assert "postgres" in data
+        assert "redis" in data
+
+    def test_atomic_write_no_partial(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "cid1", "redis://localhost", "redis:7", lock)
+        # Verify no .tmp file left behind
+        assert not (tmp_path / "containers.lock.tmp").exists()
+
+
+class TestRemoveLockEntry:
+    def test_removes_existing_entry(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "r1", "redis://...", "redis:7", lock)
+        write_lock("postgres", "p1", "pg://...", "postgres:16", lock)
+        remove_lock_entry("redis", lock)
+        assert "redis" not in read_lock(lock)
+        assert "postgres" in read_lock(lock)
+
+    def test_removes_last_entry_deletes_file(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "r1", "redis://...", "redis:7", lock)
+        remove_lock_entry("redis", lock)
+        assert not lock.exists()
+
+    def test_missing_key_is_noop(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "r1", "redis://...", "redis:7", lock)
+        remove_lock_entry("postgres", lock)  # should not raise
+        assert "redis" in read_lock(lock)
+
+
+class TestClearLock:
+    def test_deletes_file(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        lock.write_text("{}", encoding="utf-8")
+        clear_lock(lock)
+        assert not lock.exists()
+
+    def test_noop_if_missing(self, tmp_path):
+        clear_lock(tmp_path / "nonexistent.lock")  # should not raise
+
+
+class TestContainerAlive:
+    def test_running_container(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="true\n")
+            assert container_alive("abc123") is True
+
+    def test_stopped_container(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="false\n")
+            assert container_alive("abc123") is False
+
+    def test_docker_error_returns_false(self):
+        with patch("subprocess.run", side_effect=Exception("docker not found")):
+            assert container_alive("abc123") is False
+
+    def test_nonzero_returncode(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert container_alive("abc123") is False
+
+
+class TestStopContainer:
+    def test_stop_and_rm_called(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = stop_container("abc123")
+        assert result is True
+        assert mock_run.call_count == 2
+        cmds = [c[0][0] for c in mock_run.call_args_list]
+        assert any("stop" in cmd for cmd in cmds)
+        assert any("rm" in cmd for cmd in cmds)
+
+    def test_exception_returns_false(self):
+        with patch("subprocess.run", side_effect=Exception("timeout")):
+            assert stop_container("abc123") is False
+
+
+class TestTeardownAll:
+    def test_stops_all_containers(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "rid1", "redis://...", "redis:7", lock)
+        write_lock("postgres", "pgid1", "pg://...", "postgres:16", lock)
+
+        with patch("quell.infra.lockfile.stop_container", return_value=True) as mock_stop:
+            torn = teardown_all(lock)
+
+        assert set(torn) == {"redis", "postgres"}
+        assert not lock.exists()
+        assert mock_stop.call_count == 2
+
+    def test_empty_lockfile_returns_empty(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        torn = teardown_all(lock)
+        assert torn == []
+
+
+# ---------------------------------------------------------------------------
+# resolver
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSpecs:
+    def test_known_tags_resolved(self):
+        specs = resolve_specs({"postgres", "redis"})
+        tags = {s.tag for s in specs}
+        assert "postgres" in tags
+        assert "redis" in tags
+
+    def test_unknown_tag_skipped(self):
+        specs = resolve_specs({"postgres", "imaginary_db"})
+        tags = {s.tag for s in specs}
+        assert "imaginary_db" not in tags
+        assert "postgres" in tags
+
+    def test_empty_set_returns_empty(self):
+        assert resolve_specs(set()) == []
+
+    def test_deterministic_order(self):
+        specs1 = resolve_specs({"redis", "postgres", "mongo"})
+        specs2 = resolve_specs({"mongo", "redis", "postgres"})
+        assert [s.tag for s in specs1] == [s.tag for s in specs2]
+
+
+class TestTagsFromImportSignals:
+    def test_basic_mapping(self):
+        tags = tags_from_import_signals(["psycopg2", "redis"])
+        assert "postgres" in tags
+        assert "redis" in tags
+
+    def test_celery_with_pika_removes_redis(self):
+        tags = tags_from_import_signals(["celery", "pika"])
+        assert "rabbitmq" in tags
+        assert "redis" not in tags
+
+    def test_celery_with_pika_and_direct_redis_keeps_redis(self):
+        tags = tags_from_import_signals(["celery", "pika", "redis"])
+        assert "rabbitmq" in tags
+        assert "redis" in tags
+
+    def test_celery_without_pika_keeps_redis(self):
+        tags = tags_from_import_signals(["celery", "redis"])
+        assert "redis" in tags
+
+    def test_unknown_imports_ignored(self):
+        tags = tags_from_import_signals(["numpy", "pandas"])
+        assert tags == set()
+
+    def test_custom_signals(self):
+        custom = {"mydb": "postgres"}
+        tags = tags_from_import_signals(["mydb"], import_signals=custom)
+        assert "postgres" in tags
+
+
+# ---------------------------------------------------------------------------
+# fixture_gen
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateFixture:
+    def test_fixture_name_in_output(self):
+        spec = CONTAINER_SPECS["redis"]
+        src = generate_fixture(spec)
+        assert spec.fixture_name in src
+
+    def test_env_key_in_output(self):
+        spec = CONTAINER_SPECS["postgres"]
+        src = generate_fixture(spec)
+        assert spec.connection_env_key in src
+
+    def test_pytest_fixture_decorator(self):
+        spec = CONTAINER_SPECS["redis"]
+        src = generate_fixture(spec)
+        assert "@pytest.fixture" in src
+
+    def test_module_scope(self):
+        spec = CONTAINER_SPECS["redis"]
+        src = generate_fixture(spec)
+        assert 'scope="module"' in src
+
+
+class TestGenerateConftestBlock:
+    def test_guard_comments_present(self):
+        block = generate_conftest_block([CONTAINER_SPECS["redis"]])
+        assert _GUARD_START in block
+        assert _GUARD_END in block
+
+    def test_multiple_specs_included(self):
+        block = generate_conftest_block([CONTAINER_SPECS["redis"], CONTAINER_SPECS["postgres"]])
+        assert CONTAINER_SPECS["redis"].fixture_name in block
+        assert CONTAINER_SPECS["postgres"].fixture_name in block
+
+
+class TestInjectIntoConftest:
+    def test_appends_to_empty_file(self, tmp_path):
+        conftest = tmp_path / "conftest.py"
+        conftest.write_text("", encoding="utf-8")
+        result = inject_into_conftest(str(conftest), [CONTAINER_SPECS["redis"]])
+        assert _GUARD_START in result
+        assert CONTAINER_SPECS["redis"].fixture_name in result
+
+    def test_replaces_existing_block(self, tmp_path):
+        conftest = tmp_path / "conftest.py"
+        old_block = f"{_GUARD_START}\n# old content\n{_GUARD_END}\n"
+        conftest.write_text(old_block, encoding="utf-8")
+        result = inject_into_conftest(str(conftest), [CONTAINER_SPECS["postgres"]])
+        assert "# old content" not in result
+        assert CONTAINER_SPECS["postgres"].fixture_name in result
+
+    def test_nonexistent_file_creates_content(self, tmp_path):
+        conftest = tmp_path / "conftest.py"
+        result = inject_into_conftest(str(conftest), [CONTAINER_SPECS["redis"]])
+        assert _GUARD_START in result
+
+    def test_existing_user_code_preserved(self, tmp_path):
+        conftest = tmp_path / "conftest.py"
+        user_code = "import os\n\ndef my_fixture(): pass\n"
+        conftest.write_text(user_code, encoding="utf-8")
+        result = inject_into_conftest(str(conftest), [CONTAINER_SPECS["redis"]])
+        assert "def my_fixture" in result
+        assert "import os" in result
+
+
+# ---------------------------------------------------------------------------
+# engine
+# ---------------------------------------------------------------------------
+
+
+class TestContainerSession:
+    def test_register_and_get(self):
+        s = ContainerSession()
+        s.register("redis", "redis://localhost:6379")
+        assert s.get_url("redis") == "redis://localhost:6379"
+
+    def test_get_unknown_returns_none(self):
+        s = ContainerSession()
+        assert s.get_url("postgres") is None
+
+    def test_env_vars_includes_rollback_flag(self):
+        s = ContainerSession()
+        s.register("redis", "redis://localhost:6379")
+        env = s.env_vars
+        assert env.get("QUELL_TRANSACTION_ROLLBACK") == "true"
+
+    def test_env_vars_includes_connection_url(self):
+        s = ContainerSession()
+        s.register("redis", "redis://localhost:6379")
+        env = s.env_vars
+        spec = _SPECS["redis"]
+        assert env.get(spec.connection_env_key) == "redis://localhost:6379"
+
+    def test_tags_property(self):
+        s = ContainerSession()
+        s.register("redis", "redis://localhost:6379")
+        s.register("postgres", "postgresql://localhost:5432/quell")
+        assert s.tags == {"redis", "postgres"}
+
+
+class TestContainerEnginePrepare:
+    def test_empty_tags_returns_empty_session(self, tmp_path):
+        engine = ContainerEngine(lock_path=tmp_path / "containers.lock")
+        session = engine.prepare(set())
+        assert session.tags == set()
+
+    def test_reuses_alive_container(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "existing_cid", "redis://localhost:6380", "redis:7", lock)
+
+        engine = ContainerEngine(lock_path=lock)
+        with patch("quell.infra.engine.container_alive", return_value=True):
+            session = engine.prepare({"redis"})
+
+        assert session.get_url("redis") == "redis://localhost:6380"
+
+    def test_starts_new_when_not_alive(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        engine = ContainerEngine(lock_path=lock)
+
+        with (
+            patch("quell.infra.engine.container_alive", return_value=False),
+            patch.object(engine, "_start", return_value="redis://localhost:9999") as mock_start,
+            patch("quell.infra.specs.show_trust_message_once"),
+        ):
+            session = engine.prepare({"redis"})
+
+        mock_start.assert_called_once()
+        assert session.get_url("redis") == "redis://localhost:9999"
+
+    def test_unknown_tag_skipped(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        engine = ContainerEngine(lock_path=lock)
+        with patch("quell.infra.specs.show_trust_message_once"):
+            session = engine.prepare({"does_not_exist"})
+        assert session.tags == set()
+
+
+class TestContainerEngineTeardown:
+    def test_teardown_all_when_tags_none(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        engine = ContainerEngine(lock_path=lock)
+        with patch("quell.infra.engine.teardown_all", return_value=["redis"]) as mock_td:
+            result = engine.teardown()
+        mock_td.assert_called_once_with(lock)
+        assert result == ["redis"]
+
+    def test_teardown_specific_tags(self, tmp_path):
+        lock = tmp_path / "containers.lock"
+        write_lock("redis", "rid1", "redis://...", "redis:7", lock)
+        engine = ContainerEngine(lock_path=lock)
+
+        with patch("quell.infra.engine.container_alive", return_value=True), \
+             patch("quell.infra.engine.stop_container", return_value=True) as mock_stop:
+            result = engine.teardown({"redis"})
+
+        mock_stop.assert_called_once_with("rid1")
+        assert "redis" in result


### PR DESCRIPTION
## Summary
- `lockfile.py`: atomic JSON lock with `.lock.tmp` atomic rename
- `resolver.py`: tag→ContainerSpec resolution, Celery broker ambiguity handled
- `fixture_gen.py`: pytest fixture code gen with guard-comment injection
- `engine.py`: ContainerEngine prepare/teardown, ContainerSession with QUELL_TRANSACTION_ROLLBACK=true
- `verifier.py`: env.setdefault QUELL_TRANSACTION_ROLLBACK=false for Phase 2 isolation
- 51 unit tests, all passing, ruff clean

## Test plan
- [ ] `uv run pytest tests/unit/test_infra_engine.py -v` — 51 tests pass
- [ ] `uv run ruff check quell/infra/ quell/core/verifier.py` — no errors
- [ ] CI matrix green across Python 3.10-3.14

Closes #16