### PR TITLE
docs: update README and docs for v1.0.0 (QuellGraph, containers, confidence scores)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,18 @@
 
 Quelltest reads your Python docstrings, Pydantic models, and PySpark schemas — extracts every testable requirement — generates a verified pytest test for each gap — and writes it to disk only after proving it catches real violations.
 
+**v1.0.0** — infrastructure-aware verified testing: QuellGraph SQLite code-intelligence graph,
+ephemeral Docker containers, and per-test confidence scores.
+
 No LLM key required. No code leaves your machine.
 
 ```bash
 pip install quelltest
 quell check src/ --fix --no-llm
+
+# v1.0.0: build code-intelligence graph, run with auto-containers
+quell graph build src/
+quell check src/ --with-containers --fix --min-confidence 70
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,62 @@
-# Quell Documentation
+# Quelltest Documentation
 
-> *Quell your survivors. Strengthen your tests.*
+> *Your specs say what your code should do. Quelltest proves it.*
 
-Quell auto-generates verified killing tests for survived mutants from mutmut and Stryker.
+Quelltest reads specifications that already exist in your codebase — docstrings, Pydantic models,
+PySpark schemas — extracts every testable requirement, generates a verified pytest test for each
+gap, and writes it to disk only after proving it catches real violations.
 
-## Overview
+**v1.0.0** introduces infrastructure-aware verified testing: QuellGraph, ephemeral containers,
+and per-test confidence scores.
 
-- **What it does**: Reads mutation testing results, generates pytest assertions, verifies each test kills the mutant, writes only verified tests to your test file.
-- **Privacy-first**: Code never leaves your machine (unless you configure an external LLM).
-- **Safety**: Every write is auto-restored on failure. Full audit log maintained.
+## Guides
 
-## Getting Started
+- [Quick Start](quickstart.md) — install, first run, CI setup
+- [Configuration](configuration.md) — `quell.toml` reference
+- [GitHub Integration](github-integration.md) — GitHub Actions + PR annotations
+- [GitHub Actions](github-actions.yml) — composite action reference
 
-See the [Quick Start](quickstart.md) guide.
+## Key concepts
 
-## Configuration
+### Two-phase verification (the moat)
+Every generated test must:
+1. **Pass** on correct code — proves the test is valid
+2. **Fail** on violated code — proves the test catches the bug
 
-See the [Configuration](configuration.md) reference.
+Only tests that pass both phases are written to disk.
+
+### QuellGraph (v1.0.0)
+A persistent SQLite code-intelligence graph at `.quellgraph/graph.db`.
+Tracks transitive infra dependencies via BFS across call chains.
+
+```bash
+quell graph build src/          # cold build — scans all .py files
+quell graph show                # list all functions + infra tags
+quell graph why my_func         # explain why a function needs infra
+quell graph stale               # list functions affected by recent changes
+quell graph stats               # totals: functions, classes, infra-dependent
+```
+
+### Ephemeral containers (v1.0.0)
+```bash
+quell check src/ --with-containers     # auto-start postgres/redis/etc.
+quell check src/ --keep-containers     # leave containers running after run
+quell teardown                         # stop all quelltest-managed containers
+```
+
+Quelltest **never** reads your real `DATABASE_URL` or credentials.
+All containers use hardcoded ephemeral credentials and are destroyed after the run.
+
+### Confidence scores (v1.0.0)
+Every generated test receives a 0–100 confidence score across 6 factors:
+annotation coverage, constraint clarity, dependency clarity, graph coverage,
+docstring quality, and mutation strength.
+
+| Tier   | Score | Written? | Runs in CI? |
+|--------|-------|----------|-------------|
+| HIGH   | ≥ 85  | yes      | yes         |
+| MEDIUM | ≥ 70  | yes      | yes         |
+| LOW    | ≥ 50  | yes      | no          |
+| SKIP   | < 50  | no       | no          |
+
+Override with `--min-confidence N` (write gate) or set `ci_confidence` in `quell.toml`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,45 +3,96 @@
 ## Prerequisites
 
 - Python 3.11+
-- mutmut or Stryker installed and run on your project
+- Docker Desktop (optional — only needed for `--with-containers`)
 
 ## Installation
 
 ```bash
-pip install quell
+pip install quelltest
 ```
 
-## Step 1: Run mutation testing
+## Step 1: Run quell check
+
+Point `quell check` at your source directory. It reads docstrings, Pydantic models,
+and PySpark schemas, generates verified pytest tests, and writes only those that pass
+two-phase verification.
 
 ```bash
-# Python
-mutmut run
-
-# JavaScript/TypeScript
-npx stryker run --reporters=json
+quell check src/
 ```
 
-## Step 2: Scan survivors
+Add `--fix` to write verified tests to disk automatically:
 
 ```bash
-quell scan
+quell check src/ --fix
 ```
 
-## Step 3: Fix interactively
+## Step 2: Build the code-intelligence graph (v1.0.0)
+
+QuellGraph scans your project AST and tracks transitive infrastructure dependencies.
+Run once; subsequent builds are incremental (only changed files re-parsed).
 
 ```bash
-quell fix
+quell graph build src/
+quell graph show              # list functions and their infra tags
+quell graph why process_payment   # explain infra dependency chain
 ```
 
-## Step 4: Auto-fix
+## Step 3: Run with infrastructure containers (v1.0.0)
+
+If your functions depend on postgres, redis, or other infrastructure, pass
+`--with-containers` to auto-start throwaway Docker containers:
 
 ```bash
-quell auto --dry-run  # preview first
-quell auto            # apply all
+quell check src/ --with-containers --fix
+```
+
+Quelltest uses only hardcoded ephemeral credentials — your real `DATABASE_URL`
+is never read. Containers are torn down automatically after the run.
+
+To stop containers manually:
+
+```bash
+quell teardown
+```
+
+## Step 4: Filter by confidence score (v1.0.0)
+
+Each generated test receives a 0–100 confidence score. Use `--min-confidence`
+to control which tests are written:
+
+```bash
+quell check src/ --fix --min-confidence 70   # write only MEDIUM+ tests
+quell check src/ --fix --min-confidence 85   # write only HIGH tests
+```
+
+## Step 5: Set up CI
+
+```bash
+quell install --pr   # writes .github/workflows/quelltest.yml
+```
+
+Or use the composite action directly in your workflow:
+
+```yaml
+- uses: shashank7109/quelltest_lib@v1.0.0
+  with:
+    source-dir: src/
+    fail-on-gaps: 'true'
+    min-confidence: '70'
 ```
 
 ## Configuration
 
-```bash
-quell init  # adds [tool.quell] to pyproject.toml
+Add `[tool.quelltest]` to your `pyproject.toml`:
+
+```toml
+[tool.quelltest]
+llm_provider = "anthropic"        # or "ollama" for local
+llm_model = "claude-sonnet-4-5"
+auto_write = false
+score_threshold = 0.0
+ci_confidence = 70                # minimum confidence to run in CI
 ```
+
+Or create `quell.toml` in your project root with the same keys.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quelltest"
-version = "0.9.9.4"
+version = "1.0.0"
 description = "Your code says what it should do. Quell proves it."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_quellgraph_builder.py
+++ b/tests/unit/test_quellgraph_builder.py
@@ -1,6 +1,8 @@
 """Tests for QuellGraphBuilder — incremental SQLite graph builder."""
 from __future__ import annotations
 
+import json
+import sqlite3
 import textwrap
 from pathlib import Path
 
@@ -95,7 +97,6 @@ class TestInfraTagPropagation:
         self, db: QuellGraphBuilder, project: Path
     ) -> None:
         db.build(project)
-        import sqlite3
         conn = sqlite3.connect(str(db._db_path))
         conn.row_factory = sqlite3.Row
         row = conn.execute(
@@ -103,7 +104,6 @@ class TestInfraTagPropagation:
         ).fetchone()
         conn.close()
         assert row is not None
-        import json
         tags = json.loads(row["infra_tags"] or "[]")
         assert "postgres" in tags
 
@@ -111,7 +111,6 @@ class TestInfraTagPropagation:
         self, db: QuellGraphBuilder, project: Path
     ) -> None:
         db.build(project)
-        import sqlite3, json
         conn = sqlite3.connect(str(db._db_path))
         conn.row_factory = sqlite3.Row
         row = conn.execute(
@@ -123,13 +122,77 @@ class TestInfraTagPropagation:
         assert tags == []
         assert row["is_pure"] == 1
 
+    def test_bfs_three_hop_propagation(self, db: QuellGraphBuilder, tmp_path: Path) -> None:
+        """
+        BFS infra-tag propagation over a synthetic 3-hop call chain.
+
+        get_user() → db_query() → session_exec() → sqlalchemy Session param
+        sqlalchemy is only imported in the file containing session_exec.
+        get_user must inherit the postgres tag through BFS.
+        """
+        src = tmp_path / "hops"
+        src.mkdir()
+
+        # hop3.py: session_exec has Session param → direct postgres tag via import + param type
+        (src / "hop3.py").write_text(
+            textwrap.dedent("""\
+            from sqlalchemy.orm import Session
+
+            def session_exec(db: Session) -> list:
+                return db.execute("SELECT 1").fetchall()
+            """),
+            encoding="utf-8",
+        )
+
+        # hop2.py: db_query calls session_exec — no direct sqlalchemy import
+        (src / "hop2.py").write_text(
+            textwrap.dedent("""\
+            from hop3 import session_exec
+
+            def db_query():
+                return session_exec(None)
+            """),
+            encoding="utf-8",
+        )
+
+        # hop1.py: get_user calls db_query — pure by direct inspection
+        (src / "hop1.py").write_text(
+            textwrap.dedent("""\
+            from hop2 import db_query
+
+            def get_user(user_id: int) -> dict:
+                return db_query()
+            """),
+            encoding="utf-8",
+        )
+
+        db.build(src)
+
+        conn = sqlite3.connect(str(db._db_path))
+        conn.row_factory = sqlite3.Row
+
+        row_session = conn.execute(
+            "SELECT infra_tags FROM functions WHERE name='session_exec'"
+        ).fetchone()
+        row_get_user = conn.execute(
+            "SELECT infra_tags FROM functions WHERE name='get_user'"
+        ).fetchone()
+        conn.close()
+
+        assert row_session is not None
+        assert "postgres" in json.loads(row_session["infra_tags"] or "[]"), \
+            "session_exec (direct sqlalchemy import) must have postgres tag"
+
+        assert row_get_user is not None
+        assert "postgres" in json.loads(row_get_user["infra_tags"] or "[]"), \
+            "get_user must inherit postgres via 3-hop BFS: get_user→db_query→session_exec→sqlalchemy"
+
 
 class TestAnnotationCoverage:
     def test_fully_typed_function_has_high_coverage(
         self, db: QuellGraphBuilder, project: Path
     ) -> None:
         db.build(project)
-        import sqlite3
         conn = sqlite3.connect(str(db._db_path))
         conn.row_factory = sqlite3.Row
         row = conn.execute(
@@ -145,7 +208,6 @@ class TestAnnotationCoverage:
         self, db: QuellGraphBuilder, project: Path
     ) -> None:
         db.build(project)
-        import sqlite3
         conn = sqlite3.connect(str(db._db_path))
         conn.row_factory = sqlite3.Row
         row = conn.execute(


### PR DESCRIPTION
## Summary

- `README.md`: adds v1.0.0 highlight, new CLI examples for `quell graph build` and `--with-containers`
- `docs/index.md`: full rewrite — QuellGraph section, ephemeral containers section, confidence tier table
- `docs/quickstart.md`: full rewrite — replaces stale mutmut-only flow with current `quell check`, `quell graph build`, `--with-containers`, `--min-confidence` workflow

## No code changes
Pure documentation update to match the v1.0.0 release.