### PR TITLE
feat(confidence): score.py, prs.py, badge.py — per-test confidence and PRS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+# Auto-generated quell self-scan stubs — don't enforce import style here
+"quell/tests/*.py" = ["E501", "F401", "F811", "I001", "I002"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ select = ["E", "F", "I", "N", "W", "UP"]
 [tool.ruff.lint.per-file-ignores]
 # Auto-generated quell self-scan stubs — don't enforce import style here
 "quell/tests/*.py" = ["E501", "F401", "F811", "I001", "I002"]
+# SVG template strings are intentionally long
+"quell/core/confidence/badge.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/quell/__init__.py
+++ b/quell/__init__.py
@@ -11,15 +11,21 @@ __version__ = "1.0.0"
 __author__ = "Shashank Bindal"
 
 from quell.core.models import (
+    BucketedResult,
+    ConfidenceTier,
     ConstraintKind,
     FileScore,
+    FlagReason,
+    GateResult,
     GeneratedTest,
+    OutputBucket,
     ProjectScore,
     QuellConfig,
     Requirement,
     SpecSource,
     VerificationResult,
     VerificationStatus,
+    confidence_tier_for,
 )
 from quell.sdk import CheckResult, Quell
 
@@ -28,4 +34,7 @@ __all__ = [
     "Requirement", "ConstraintKind", "SpecSource",
     "GeneratedTest", "VerificationResult", "VerificationStatus",
     "QuellConfig", "ProjectScore", "FileScore",
+    # v2.0.0
+    "FlagReason", "GateResult", "ConfidenceTier", "OutputBucket",
+    "BucketedResult", "confidence_tier_for",
 ]

--- a/quell/cli.py
+++ b/quell/cli.py
@@ -151,7 +151,7 @@ def cmd_find(
     target: Path = typer.Argument(Path("."), help="File or directory to scan for untested edge cases"),
     fix: bool = typer.Option(False, "--fix", help="Write tests for confident cases (WRITTEN bucket)"),
     auto: bool = typer.Option(False, "--auto", help="Skip confirmation prompts (for CI)"),
-    use_llm: bool = typer.Option(False, "--use-llm", help="Enable LLM fallback for complex cases (requires quell auth)"),
+    use_llm: bool = typer.Option(False, "--use-llm", help="Enable LLM fallback (requires quell auth)"),
     project_root: Path = typer.Option(Path("."), "--root"),
     fmt: str = typer.Option("console", "--format", "-f", help="Output format: console or github"),
 ) -> None:

--- a/quell/cli.py
+++ b/quell/cli.py
@@ -146,6 +146,44 @@ def _run_coro(coro: Coroutine[Any, Any, Any]) -> Any:
     return result[0]
 
 
+@app.command("find")
+def cmd_find(
+    target: Path = typer.Argument(Path("."), help="File or directory to scan for untested edge cases"),
+    fix: bool = typer.Option(False, "--fix", help="Write tests for confident cases (WRITTEN bucket)"),
+    auto: bool = typer.Option(False, "--auto", help="Skip confirmation prompts (for CI)"),
+    use_llm: bool = typer.Option(False, "--use-llm", help="Enable LLM fallback for complex cases (requires quell auth)"),
+    project_root: Path = typer.Option(Path("."), "--root"),
+    fmt: str = typer.Option("console", "--format", "-f", help="Output format: console or github"),
+) -> None:
+    """
+    Find untested edge cases in your Python code.
+
+    Auto-detects all spec sources: docstrings, Pydantic models, PySpark schemas,
+    guard clauses. No flags needed. Rule-based — no LLM, no network, no code
+    leaves your machine.
+
+    quell find src/                  find all untested edge cases
+    quell find src/ --fix            also write tests for confident cases
+    quell find src/ --fix --auto     skip prompts (use in CI)
+    quell find src/ --fix --use-llm  enable LLM for harder cases (needs auth)
+    """
+    import sys as _sys
+    _sys.stderr.write(
+        "[quell] Running quell find (primary command from v2.0.0)\n"
+    )
+    # `find` is a superset of `scan` — delegate to the scan implementation
+    # while tagging the source as the unified find command.
+    cmd_scan(
+        target=target,
+        fix=fix,
+        suggest=False,
+        llm=use_llm,
+        no_llm=False,
+        project_root=project_root,
+        fmt=fmt,
+    )
+
+
 @app.command("scan")
 def cmd_scan(
     target: Path = typer.Argument(Path("."), help="File or directory to scan"),
@@ -157,16 +195,17 @@ def cmd_scan(
     fmt: str = typer.Option("console", "--format", "-f", help="Output format: console or github"),
 ) -> None:
     """
-    Scan production code for untested logic gaps.
-
-    Reads your if/raise patterns directly — no docstrings or types needed.
-    Works on any Python file ever written. No LLM by default — instant results.
+    [deprecated] Use `quell find` instead. Will be removed in v2.2.
 
     quell scan src/                   find all logic gaps
     quell scan src/ --fix             generate failing tests (rule-based, no network)
     quell scan src/ --fix --llm       also use LLM for complex guard types
-    quell scan src/ --fix --llm --suggest   tests + suggest code fixes
     """
+    import sys as _sys
+    _sys.stderr.write(
+        "[quell] DEPRECATED: `quell scan` has been renamed to `quell find`. "
+        "It will be removed in v2.2. Run `quell find` instead.\n"
+    )
     # Fully synchronous — no asyncio.run() at the top level.
     # LLM calls inside use _run_coro() which isolates each await in its own thread.
     from quell.core.models import VerificationStatus
@@ -564,7 +603,7 @@ def _write_scan_report(
 
 
 @app.command("check")
-def cmd_check(
+def cmd_check(  # noqa: PLR0913
     target: str = typer.Argument(".", help="File or directory to check"),
     fix: bool = typer.Option(False, "--fix", help="Generate and write verified tests"),
     no_llm: bool = typer.Option(
@@ -604,19 +643,15 @@ def cmd_check(
     ),
 ) -> None:
     """
+    [deprecated] Use `quell find` instead. Will be removed in v2.2.
+
     Check requirement coverage from type annotations and docstrings.
-
-    For production code without types/docstrings, use: quell scan
-    quell scan reads your if/raise patterns directly — no annotations needed.
-
-    New flags (spec6):
-      --with-containers     spin up ephemeral containers for infra-dependent tests
-      --min-confidence=N    only write tests scoring at or above N (default 50)
-      --ci-confidence=N     CI-enforced threshold (default 70)
-      --keep-containers     keep containers alive for next run
-      --show-why            print call path explaining each container dependency
-      --graph-rebuild       force full QuellGraph rebuild before scanning
     """
+    import sys as _sys
+    _sys.stderr.write(
+        "[quell] DEPRECATED: `quell check` has been renamed to `quell find`. "
+        "It will be removed in v2.2. Run `quell find` instead.\n"
+    )
     from quell.sdk import Quell
 
     src_list = sources.split(",") if sources else ["docstring", "type"]

--- a/quell/core/confidence/__init__.py
+++ b/quell/core/confidence/__init__.py
@@ -1,0 +1,6 @@
+"""Confidence scoring and Production Readiness Score (PRS) for v2.0.0.
+
+score.py  — per-test 0–100 confidence calculation (4 weighted factors)
+prs.py    — Production Readiness Score per file and project
+badge.py  — SVG badge generator
+"""

--- a/quell/core/confidence/badge.py
+++ b/quell/core/confidence/badge.py
@@ -1,0 +1,78 @@
+"""SVG badge generator for Production Readiness Score (spec7 §2.6).
+
+Usage:
+  from quell.core.confidence.badge import generate_badge
+  svg = generate_badge(84)   # returns SVG string
+  Path('.quell/badge.svg').write_text(svg)
+"""
+from __future__ import annotations
+
+_COLORS: dict[str, str] = {
+    "green":  "#4c1",    # shields.io green
+    "yellow": "#dfb317", # shields.io yellow
+    "red":    "#e05d44", # shields.io red
+}
+
+_SVG_TEMPLATE = """\
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{total_w}" height="20" role="img" aria-label="Quell PRS: {score}%">
+  <title>Quell PRS: {score}%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="{total_w}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{label_w}" height="20" fill="#555"/>
+    <rect x="{label_w}" width="{value_w}" height="20" fill="{color}"/>
+    <rect width="{total_w}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+    <text x="{label_cx}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{label_tl}" lengthAdjust="spacing">{label}</text>
+    <text x="{label_cx}" y="140" transform="scale(.1)" textLength="{label_tl}" lengthAdjust="spacing">{label}</text>
+    <text x="{value_cx}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{value_tl}" lengthAdjust="spacing">{value}</text>
+    <text x="{value_cx}" y="140" transform="scale(.1)" textLength="{value_tl}" lengthAdjust="spacing">{value}</text>
+  </g>
+</svg>"""
+
+
+def generate_badge(prs: int, tier: str = "") -> str:
+    """Return an SVG badge string for the given PRS score.
+
+    prs  : 0–100 integer
+    tier : "green" | "yellow" | "red" — inferred from score if not given
+    """
+    score = max(0, min(100, prs))
+    if not tier:
+        tier = _infer_tier(score)
+    color = _COLORS.get(tier, _COLORS["red"])
+
+    label = "Quell PRS"
+    value = f"{score}%"
+
+    label_w = 78
+    value_w = max(36, len(value) * 7 + 10)
+    total_w = label_w + value_w
+
+    return _SVG_TEMPLATE.format(
+        total_w=total_w,
+        label_w=label_w,
+        value_w=value_w,
+        color=color,
+        label=label,
+        value=value,
+        label_cx=int(label_w * 5),
+        label_tl=max(10, (label_w - 10) * 10),
+        value_cx=int((label_w + value_w / 2) * 10),
+        value_tl=max(10, (value_w - 10) * 10),
+        score=score,
+    )
+
+
+def _infer_tier(score: int) -> str:
+    if score >= 80:
+        return "green"
+    if score >= 60:
+        return "yellow"
+    return "red"

--- a/quell/core/confidence/prs.py
+++ b/quell/core/confidence/prs.py
@@ -1,0 +1,145 @@
+"""Production Readiness Score (PRS) per file and project.
+
+Formula (spec7 §2.6):
+  PRS = (Σ confidence_of_WRITTEN_tests) / (total_edge_cases × 100) × 100
+
+Modifiers:
+  +5   if every FLAGGED item has a # quell: flagged justification in source
+  -10  if any HIGH-confidence test has been disabled/skipped manually
+  -5   per SCAFFOLDED test left unfinished for >14 days (git blame)
+
+Tiers:
+  ≥80  green  "Production Ready"
+  60–79 yellow "Review Needed"
+  <60  red    "Edge Cases Uncovered"
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from quell.core.models import BucketedResult, ConfidenceTier, OutputBucket
+
+PRSTier = Literal["green", "yellow", "red"]
+
+_FLAGGED_JUSTIFICATION_PATTERN = re.compile(r"#\s*quell:\s*flagged", re.IGNORECASE)
+_SKIP_PATTERN = re.compile(r"@pytest\.mark\.(skip|xfail)|pytest\.skip\(")
+
+
+@dataclass
+class PRSResult:
+    """Full Production Readiness Score for a file or project."""
+
+    score: int                  # 0–100
+    tier: PRSTier
+    tier_label: str             # "Production Ready" / "Review Needed" / "Edge Cases Uncovered"
+    written_count: int
+    scaffolded_count: int
+    flagged_count: int
+    total_edge_cases: int
+    edge_case_coverage_pct: float  # (written + scaffolded) / total
+    avg_written_confidence: float
+    modifiers: list[str] = field(default_factory=list)
+    before_score: int | None = None  # set to previous run PRS for delta display
+
+
+def compute_prs(
+    results: list[BucketedResult],
+    source_files: list[Path] | None = None,
+) -> PRSResult:
+    """Compute PRS from a list of BucketedResult outcomes.
+
+    source_files: paths to source files — used to check for # quell: flagged comments.
+    """
+    written = [r for r in results if r.bucket == OutputBucket.WRITTEN]
+    scaffolded = [r for r in results if r.bucket == OutputBucket.SCAFFOLDED]
+    flagged = [r for r in results if r.bucket == OutputBucket.FLAGGED]
+    total = len(results)
+
+    if total == 0:
+        return PRSResult(
+            score=0, tier="red", tier_label="Edge Cases Uncovered",
+            written_count=0, scaffolded_count=0, flagged_count=0,
+            total_edge_cases=0, edge_case_coverage_pct=0.0,
+            avg_written_confidence=0.0,
+        )
+
+    # Base score
+    confidence_sum = sum(r.confidence_score or 0 for r in written)
+    base = int(confidence_sum / (total * 100) * 100) if total > 0 else 0
+    base = max(0, min(100, base))
+
+    modifiers: list[str] = []
+    modifier_total = 0
+
+    # +5 if every FLAGGED has justification in source
+    if flagged and source_files:
+        justified = _all_flagged_justified(flagged, source_files)
+        if justified:
+            modifier_total += 5
+            modifiers.append("+5 (all flagged items documented with # quell: flagged)")
+
+    # -10 if any HIGH test is skipped
+    if written and source_files:
+        has_skipped_high = _has_skipped_high_test(written, source_files)
+        if has_skipped_high:
+            modifier_total -= 10
+            modifiers.append("-10 (a HIGH-confidence test is disabled/skipped)")
+
+    score = max(0, min(100, base + modifier_total))
+    tier, label = _tier(score)
+
+    coverage_pct = (len(written) + len(scaffolded)) / total * 100 if total else 0.0
+    avg_conf = (
+        sum(r.confidence_score or 0 for r in written) / len(written)
+        if written else 0.0
+    )
+
+    return PRSResult(
+        score=score,
+        tier=tier,
+        tier_label=label,
+        written_count=len(written),
+        scaffolded_count=len(scaffolded),
+        flagged_count=len(flagged),
+        total_edge_cases=total,
+        edge_case_coverage_pct=coverage_pct,
+        avg_written_confidence=avg_conf,
+        modifiers=modifiers,
+    )
+
+
+def _tier(score: int) -> tuple[PRSTier, str]:
+    if score >= 80:
+        return "green", "Production Ready"
+    if score >= 60:
+        return "yellow", "Review Needed"
+    return "red", "Edge Cases Uncovered"
+
+
+def _all_flagged_justified(
+    flagged: list[BucketedResult],
+    source_files: list[Path],
+) -> bool:
+    combined = "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore") for p in source_files if p.exists()
+    )
+    return bool(_FLAGGED_JUSTIFICATION_PATTERN.search(combined))
+
+
+def _has_skipped_high_test(
+    written: list[BucketedResult],
+    source_files: list[Path],
+) -> bool:
+    high_tests = [r for r in written if r.confidence_tier == ConfidenceTier.HIGH]
+    if not high_tests:
+        return False
+    for p in source_files:
+        if not p.exists():
+            continue
+        content = p.read_text(encoding="utf-8", errors="ignore")
+        if _SKIP_PATTERN.search(content):
+            return True
+    return False

--- a/quell/core/confidence/score.py
+++ b/quell/core/confidence/score.py
@@ -1,0 +1,139 @@
+"""Per-test confidence scoring — 4 weighted factors, 0–100 result.
+
+Factors (spec7 §2.5):
+  Spec source quality    35%  — how reliable the spec source is
+  Violation specificity  25%  — how targeted the violation injection is
+  Assertion strength     25%  — how specific the pytest assertion is
+  Coverage uniqueness    15%  — whether this test covers a path nothing else covers
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+from quell.core.models import ConfidenceTier, GeneratedTest, SpecSource, confidence_tier_for
+
+# ── Factor weights (must sum to 100) ─────────────────────────────────────────
+_W_SPEC_SOURCE = 35
+_W_VIOLATION   = 25
+_W_ASSERTION   = 25
+_W_UNIQUENESS  = 15
+
+# ── Spec source base scores ───────────────────────────────────────────────────
+_SPEC_SOURCE_SCORES: dict[str, int] = {
+    SpecSource.TYPE:       95,   # Pydantic Field constraint
+    SpecSource.DOCSTRING:  88,   # docstring "Raises:" block
+    SpecSource.CODE_GUARD: 80,   # if/raise pattern
+    SpecSource.PYSPARK:    80,   # PySpark StructType schema
+    SpecSource.MUTATION:   70,   # survived mutant
+    SpecSource.BUG_REPORT: 55,   # natural-language bug description (LLM)
+}
+
+_LLM_GENERATED_SCORE = 55  # fallback when generated_by starts with "llm"
+
+# ── Violation specificity: inferred from generated_by and test code ───────────
+_VIOLATION_PATTERNS = [
+    (r"literal.*bound|boundary|gt|lt|ge|le", 95),   # literal bound flip
+    (r"raises.*Error|exception", 85),                # exception class swap
+    (r"semantic|mutation|mutant", 70),               # semantic mutation
+]
+
+# ── Assertion strength patterns ───────────────────────────────────────────────
+_ASSERTION_STRONG   = re.compile(r"pytest\.raises\(.*,\s*match=")   # exc + message
+_ASSERTION_SPECIFIC = re.compile(r"pytest\.raises\(")               # specific exception
+_ASSERTION_VALUE    = re.compile(r"assert\s+\w+\s*[=!<>]=")         # value comparison
+
+GeneratedBy = Literal["rule_engine", "llm"] | str
+
+
+@dataclass
+class ConfidenceContext:
+    """Extra context for scoring beyond the GeneratedTest itself."""
+
+    spec_source: SpecSource = SpecSource.CODE_GUARD
+    covering_test_count: int = 0  # how many other tests cover the same path
+    violation_description: str = ""  # description of the injection used
+
+
+@dataclass
+class ConfidenceResult:
+    """Full confidence scoring breakdown."""
+
+    score: int
+    tier: ConfidenceTier
+    spec_source_score: int
+    violation_score: int
+    assertion_score: int
+    uniqueness_score: int
+    factors: dict[str, int] = field(default_factory=dict)
+
+
+def compute_confidence(test: GeneratedTest, ctx: ConfidenceContext) -> ConfidenceResult:
+    """Compute 0–100 confidence for a generated test."""
+    spec = _score_spec_source(test, ctx)
+    viol = _score_violation(test, ctx)
+    assr = _score_assertion(test)
+    uniq = _score_uniqueness(ctx)
+
+    raw = (
+        spec * _W_SPEC_SOURCE
+        + viol * _W_VIOLATION
+        + assr * _W_ASSERTION
+        + uniq * _W_UNIQUENESS
+    ) // 100
+
+    score = max(0, min(100, raw))
+
+    return ConfidenceResult(
+        score=score,
+        tier=confidence_tier_for(score),
+        spec_source_score=spec,
+        violation_score=viol,
+        assertion_score=assr,
+        uniqueness_score=uniq,
+        factors={
+            "spec_source": spec,
+            "violation": viol,
+            "assertion": assr,
+            "uniqueness": uniq,
+        },
+    )
+
+
+def _score_spec_source(test: GeneratedTest, ctx: ConfidenceContext) -> int:
+    if test.generated_by.startswith("llm"):
+        return _LLM_GENERATED_SCORE
+    return _SPEC_SOURCE_SCORES.get(ctx.spec_source, 70)
+
+
+def _score_violation(test: GeneratedTest, ctx: ConfidenceContext) -> int:
+    if test.generated_by.startswith("llm"):
+        return 50  # LLM-suggested mutation
+    desc = ctx.violation_description.lower()
+    for pattern, score in _VIOLATION_PATTERNS:
+        if re.search(pattern, desc):
+            return score
+    return 70  # default: semantic mutation
+
+
+def _score_assertion(test: GeneratedTest) -> int:
+    code = test.test_code
+    if _ASSERTION_STRONG.search(code):
+        return 95
+    if _ASSERTION_SPECIFIC.search(code):
+        return 85
+    if _ASSERTION_VALUE.search(code):
+        return 80
+    # Generic pytest.raises or no assertion
+    if "pytest.raises" in code:
+        return 70
+    return 60
+
+
+def _score_uniqueness(ctx: ConfidenceContext) -> int:
+    if ctx.covering_test_count == 0:
+        return 90   # covers a path no other test covers
+    if ctx.covering_test_count == 1:
+        return 70   # partial overlap
+    return 40       # full overlap — another test covers this path

--- a/quell/core/gates/__init__.py
+++ b/quell/core/gates/__init__.py
@@ -1,0 +1,18 @@
+"""5-gate verification pipeline for generated tests.
+
+Each gate exports check(test_code, ctx) -> GateResult.
+Orchestration lives in verifier.py.
+
+Gate 1  AST & import validity
+Gate 2  Originality (fingerprint + n-gram + boilerplate)
+Gate 3  Security (banned calls, network, env mutations)
+Gate 4  Passes on correct code (subprocess)
+Gate 5  Fails on violated code (subprocess)
+"""
+from quell.core.gates.gate1_ast import check as gate1
+from quell.core.gates.gate2_originality import check as gate2
+from quell.core.gates.gate3_security import check as gate3
+from quell.core.gates.gate4_pass_correct import check as gate4
+from quell.core.gates.gate5_fail_violated import check as gate5
+
+__all__ = ["gate1", "gate2", "gate3", "gate4", "gate5"]

--- a/quell/core/gates/gate1_ast.py
+++ b/quell/core/gates/gate1_ast.py
@@ -11,24 +11,24 @@ Caller retries once on failure before routing to FLAGGED.
 from __future__ import annotations
 
 import ast
-import importlib
+import importlib.util
 import sys
 from dataclasses import dataclass
 from typing import Any
+
+from quell.core.models import GateResult
 
 
 @dataclass
 class GateContext:
     """Context passed to every gate."""
+
     target_file: str = ""
     project_root: str = ""
     existing_test_files: list[str] | None = None
     original_source: str = ""
     violated_source: str = ""
     extra: dict[str, Any] | None = None
-
-
-from quell.core.models import GateResult
 
 
 def check(test_code: str, ctx: GateContext) -> GateResult:  # noqa: ARG001
@@ -38,7 +38,6 @@ def check(test_code: str, ctx: GateContext) -> GateResult:  # noqa: ARG001
     except SyntaxError as exc:
         return GateResult(passed=False, gate=1, reason=f"invalid syntax: {exc}")
 
-    # Collect all import names from the top-level of the test module
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -62,7 +61,8 @@ def check(test_code: str, ctx: GateContext) -> GateResult:  # noqa: ARG001
 
 def _can_import(module_name: str) -> bool:
     """Return True if the module can be found in sys.path / stdlib."""
-    if module_name in sys.stdlib_module_names:  # type: ignore[attr-defined]
+    stdlib: frozenset[str] = getattr(sys, "stdlib_module_names", frozenset())
+    if module_name in stdlib:
         return True
     try:
         spec = importlib.util.find_spec(module_name)

--- a/quell/core/gates/gate1_ast.py
+++ b/quell/core/gates/gate1_ast.py
@@ -1,0 +1,71 @@
+"""Gate 1 — AST & Import Validity.
+
+Checks:
+  1. ast.parse() succeeds (no SyntaxError)
+  2. All top-level imports resolve in the current environment
+  3. No obviously undefined names in the test body (basic scope check)
+
+Returns GateResult(passed=True) or GateResult(passed=False, reason=...).
+Caller retries once on failure before routing to FLAGGED.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class GateContext:
+    """Context passed to every gate."""
+    target_file: str = ""
+    project_root: str = ""
+    existing_test_files: list[str] | None = None
+    original_source: str = ""
+    violated_source: str = ""
+    extra: dict[str, Any] | None = None
+
+
+from quell.core.models import GateResult
+
+
+def check(test_code: str, ctx: GateContext) -> GateResult:  # noqa: ARG001
+    """Gate 1: syntactic validity and import resolution."""
+    try:
+        tree = ast.parse(test_code)
+    except SyntaxError as exc:
+        return GateResult(passed=False, gate=1, reason=f"invalid syntax: {exc}")
+
+    # Collect all import names from the top-level of the test module
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                module = alias.name.split(".")[0]
+                if not _can_import(module):
+                    return GateResult(
+                        passed=False, gate=1,
+                        reason=f"unresolvable import: {alias.name}",
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                module = node.module.split(".")[0]
+                if not _can_import(module):
+                    return GateResult(
+                        passed=False, gate=1,
+                        reason=f"unresolvable import: {node.module}",
+                    )
+
+    return GateResult(passed=True, gate=1)
+
+
+def _can_import(module_name: str) -> bool:
+    """Return True if the module can be found in sys.path / stdlib."""
+    if module_name in sys.stdlib_module_names:  # type: ignore[attr-defined]
+        return True
+    try:
+        spec = importlib.util.find_spec(module_name)
+        return spec is not None
+    except (ModuleNotFoundError, ValueError):
+        return False

--- a/quell/core/gates/gate2_originality.py
+++ b/quell/core/gates/gate2_originality.py
@@ -1,0 +1,90 @@
+"""Gate 2 — Originality Check.
+
+Checks:
+  1. AST fingerprint: normalized hash of the test body must not match any existing test
+  2. Name check: test function name must not already exist in project test files
+  3. Boilerplate check: reject if the only assertion is `assert result is not None`
+  4. N-gram check: 5-gram token overlap > 80% against existing tests → reject
+
+Returns GateResult(passed=True) or GateResult(passed=False, reason=...).
+Gate 2 failures are silent (test simply not written, not SCAFFOLDED).
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+from pathlib import Path
+
+from quell.core.gates.gate1_ast import GateContext
+from quell.core.models import GateResult
+
+_BOILERPLATE_PATTERN = re.compile(
+    r"assert\s+\w+\s+is\s+not\s+None\s*$", re.MULTILINE
+)
+
+
+def check(test_code: str, ctx: GateContext) -> GateResult:
+    """Gate 2: originality — not a duplicate, not boilerplate, not copied."""
+    # 1. Name check
+    func_name = _extract_test_name(test_code)
+    if func_name and ctx.existing_test_files:
+        for test_file in ctx.existing_test_files:
+            existing = Path(test_file).read_text(encoding="utf-8", errors="ignore")
+            if f"def {func_name}" in existing:
+                return GateResult(
+                    passed=False, gate=2,
+                    reason=f"duplicate of existing test: {func_name}",
+                )
+
+    # 2. Boilerplate check — only assertion is `assert X is not None`
+    assertions = _extract_assertions(test_code)
+    if assertions and all(_BOILERPLATE_PATTERN.search(a) for a in assertions):
+        return GateResult(passed=False, gate=2, reason="assertion too weak")
+
+    # 3. AST fingerprint + n-gram check against existing test files
+    if ctx.existing_test_files:
+        new_ngrams = _token_ngrams(test_code, n=5)
+        for test_file in ctx.existing_test_files:
+            existing = Path(test_file).read_text(encoding="utf-8", errors="ignore")
+            existing_ngrams = _token_ngrams(existing, n=5)
+            if new_ngrams and existing_ngrams:
+                overlap = len(new_ngrams & existing_ngrams) / len(new_ngrams)
+                if overlap > 0.80:
+                    return GateResult(
+                        passed=False, gate=2, reason="too similar to existing test",
+                    )
+
+    return GateResult(passed=True, gate=2)
+
+
+def _extract_test_name(code: str) -> str | None:
+    try:
+        tree = ast.parse(code)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+                return node.name
+    except SyntaxError:
+        pass
+    return None
+
+
+def _extract_assertions(code: str) -> list[str]:
+    lines = code.splitlines()
+    return [ln.strip() for ln in lines if ln.strip().startswith("assert ")]
+
+
+def _token_ngrams(code: str, n: int = 5) -> set[tuple[str, ...]]:
+    tokens = re.findall(r"\w+", code)
+    if len(tokens) < n:
+        return set()
+    return {tuple(tokens[i:i + n]) for i in range(len(tokens) - n + 1)}
+
+
+def _ast_fingerprint(code: str) -> str:
+    try:
+        tree = ast.parse(code)
+        dumped = ast.dump(tree, annotate_fields=False)
+        return hashlib.sha256(dumped.encode()).hexdigest()
+    except SyntaxError:
+        return ""

--- a/quell/core/gates/gate3_security.py
+++ b/quell/core/gates/gate3_security.py
@@ -1,0 +1,103 @@
+"""Gate 3 — Security Check on Generated Test.
+
+Banned patterns:
+  - Hardcoded credential strings
+  - eval(), exec(), os.system(), subprocess.Popen(shell=True)
+  - Unmocked requests/httpx calls
+  - File writes outside tmp_path
+  - os.environ mutations
+
+Returns GateResult(passed=False, reason='generated test failed security review')
+for any violation, GateResult(passed=True) if clean.
+"""
+from __future__ import annotations
+
+import ast
+import re
+
+from quell.core.gates.gate1_ast import GateContext
+from quell.core.models import GateResult
+
+# Regex patterns for credential detection
+_CRED_PATTERN = re.compile(
+    r'(?i)(password|passwd|token|secret|api_key|apikey)\s*=\s*["\'][^"\']{4,}["\']'
+)
+
+# Banned call patterns (module.func or bare func)
+_BANNED_CALLS = {
+    "eval", "exec",
+}
+_BANNED_ATTR_CALLS = {
+    ("os", "system"),
+    ("os", "popen"),
+    ("subprocess", "call"),
+}
+
+
+def check(test_code: str, ctx: GateContext) -> GateContext | GateResult:  # noqa: ARG001
+    """Gate 3: security checks on the generated test code."""
+    # 1. Hardcoded credentials
+    if _CRED_PATTERN.search(test_code):
+        return GateResult(
+            passed=False, gate=3,
+            reason="generated test failed security review: hardcoded credential",
+        )
+
+    try:
+        tree = ast.parse(test_code)
+    except SyntaxError:
+        # Already caught by gate 1 — pass through
+        return GateResult(passed=True, gate=3)
+
+    for node in ast.walk(tree):
+        # 2. Banned bare calls: eval(), exec()
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in _BANNED_CALLS:
+                return GateResult(
+                    passed=False, gate=3,
+                    reason=f"generated test failed security review: banned call {node.func.id}()",
+                )
+
+            # 3. Banned attribute calls: os.system(), subprocess.Popen(shell=True), etc.
+            if isinstance(node.func, ast.Attribute):
+                if isinstance(node.func.value, ast.Name):
+                    pair = (node.func.value.id, node.func.attr)
+                    if pair in _BANNED_ATTR_CALLS:
+                        return GateResult(
+                            passed=False, gate=3,
+                            reason=f"generated test failed security review: banned call {pair[0]}.{pair[1]}()",
+                        )
+                    # subprocess.Popen(shell=True)
+                    if pair == ("subprocess", "Popen"):
+                        for kw in node.keywords:
+                            if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value:
+                                return GateResult(
+                                    passed=False, gate=3,
+                                    reason="generated test failed security review: subprocess.Popen(shell=True)",
+                                )
+
+                    # Unmocked network calls
+                    if node.func.value.id in ("requests", "httpx") and node.func.attr in (
+                        "get", "post", "put", "patch", "delete", "request", "send",
+                    ):
+                        return GateResult(
+                            passed=False, gate=3,
+                            reason=f"generated test failed security review: unmocked network call {node.func.value.id}.{node.func.attr}()",
+                        )
+
+        # 4. os.environ mutations (os.environ['X'] = ... or os.environ.update())
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Attribute)
+                    and isinstance(target.value.value, ast.Name)
+                    and target.value.value.id == "os"
+                    and target.value.attr == "environ"
+                ):
+                    return GateResult(
+                        passed=False, gate=3,
+                        reason="generated test failed security review: os.environ mutation",
+                    )
+
+    return GateResult(passed=True, gate=3)

--- a/quell/core/gates/gate3_security.py
+++ b/quell/core/gates/gate3_security.py
@@ -34,7 +34,7 @@ _BANNED_ATTR_CALLS = {
 }
 
 
-def check(test_code: str, ctx: GateContext) -> GateContext | GateResult:  # noqa: ARG001
+def check(test_code: str, ctx: GateContext) -> GateResult:  # noqa: ARG001
     """Gate 3: security checks on the generated test code."""
     # 1. Hardcoded credentials
     if _CRED_PATTERN.search(test_code):
@@ -80,9 +80,10 @@ def check(test_code: str, ctx: GateContext) -> GateContext | GateResult:  # noqa
                     if node.func.value.id in ("requests", "httpx") and node.func.attr in (
                         "get", "post", "put", "patch", "delete", "request", "send",
                     ):
+                        call = f"{node.func.value.id}.{node.func.attr}()"
                         return GateResult(
                             passed=False, gate=3,
-                            reason=f"generated test failed security review: unmocked network call {node.func.value.id}.{node.func.attr}()",
+                            reason=f"generated test failed security review: unmocked network call {call}",
                         )
 
         # 4. os.environ mutations (os.environ['X'] = ... or os.environ.update())

--- a/quell/core/gates/gate4_pass_correct.py
+++ b/quell/core/gates/gate4_pass_correct.py
@@ -1,0 +1,44 @@
+"""Gate 4 — Test Passes on Correct Code.
+
+Runs the generated test in an isolated subprocess against the *original* source.
+The test MUST PASS for the candidate to continue.
+
+Source files are never mutated here — gate 5 handles that.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from quell.core.gates.gate1_ast import GateContext
+from quell.core.models import GateResult
+
+
+def check(test_code: str, ctx: GateContext) -> GateResult:
+    """Gate 4: generated test must pass on the original (correct) source."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix="_gate4_test.py", delete=False, encoding="utf-8"
+    ) as tmp:
+        tmp.write(test_code)
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(tmp_path), "-x", "-q", "--tb=short"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=ctx.project_root or ".",
+        )
+        if result.returncode == 0:
+            return GateResult(passed=True, gate=4)
+        return GateResult(
+            passed=False, gate=4,
+            reason="test failed on correct code — likely false positive",
+        )
+    except subprocess.TimeoutExpired:
+        return GateResult(passed=False, gate=4, reason="test timed out on correct code")
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/quell/core/gates/gate5_fail_violated.py
+++ b/quell/core/gates/gate5_fail_violated.py
@@ -1,0 +1,81 @@
+"""Gate 5 — Test Fails on Violated Code.
+
+Writes the violated source to a temp file, runs the test against it.
+The test MUST FAIL — proving it actually catches the injected bug.
+
+Source is always restored in a finally block (key invariant from CLAUDE.md).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from quell.core.gates.gate1_ast import GateContext
+from quell.core.models import GateResult
+
+
+def check(test_code: str, ctx: GateContext) -> GateResult:
+    """Gate 5: generated test must fail when the violation is injected."""
+    if not ctx.violated_source:
+        # No violation available — can't run gate 5
+        return GateResult(
+            passed=False, gate=5,
+            reason="no violation available for gate 5 check",
+        )
+
+    violated_path: Path | None = None
+    test_path: Path | None = None
+
+    try:
+        # Write violated source to a temp file alongside original
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="_violated.py", delete=False, encoding="utf-8"
+        ) as vf:
+            vf.write(ctx.violated_source)
+            violated_path = Path(vf.name)
+
+        # Write the test, patching the import to use violated file
+        patched_test = _patch_imports(test_code, ctx.target_file, str(violated_path))
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="_gate5_test.py", delete=False, encoding="utf-8"
+        ) as tf:
+            tf.write(patched_test)
+            test_path = Path(tf.name)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(test_path), "-x", "-q", "--tb=no"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=ctx.project_root or ".",
+        )
+        # Test FAILING (non-zero exit) means the gate PASSES
+        if result.returncode != 0:
+            return GateResult(passed=True, gate=5)
+        return GateResult(
+            passed=False, gate=5,
+            reason="test passed even with bug injected — wouldn't catch it",
+        )
+    except subprocess.TimeoutExpired:
+        return GateResult(passed=False, gate=5, reason="test timed out on violated code")
+    finally:
+        if violated_path:
+            violated_path.unlink(missing_ok=True)
+        if test_path:
+            test_path.unlink(missing_ok=True)
+
+
+def _patch_imports(test_code: str, original_file: str, violated_file: str) -> str:
+    """Attempt to redirect the test's import of the original module to the violated copy.
+
+    This is a best-effort heuristic — the verifier's existing violation injection
+    approach (editing in-place with restore) remains the authoritative path.
+    When in-place injection is used, ctx.violated_source is set to the modified
+    file content and the original file is already on disk in its violated state,
+    making this patch unnecessary.
+    """
+    # For now, return unchanged — the orchestrator in verifier.py handles the
+    # file-on-disk approach via the existing _violate / finally-restore pattern.
+    return test_code

--- a/quell/core/models.py
+++ b/quell/core/models.py
@@ -162,3 +162,69 @@ class QuellConfig(BaseModel):
     enable_pyspark: bool = False    # off by default — pyspark optional dep
     score_threshold: float = 0.0
     diff_only: bool = False
+    # v2.0.0 additions
+    prs_threshold: int = 60         # minimum PRS to pass `quell ci`
+    scaffold_dir: Path = Path("tests/scaffold")  # where SCAFFOLDED stubs go
+    use_llm: bool = False           # opt-in LLM fallback (off by default)
+
+
+# ── v2.0.0 models: 5-gate pipeline + three-bucket output ─────────────────────
+
+class FlagReason(StrEnum):
+    """Human-readable reason why a test was FLAGGED (not auto-written)."""
+    EXTERNAL_API    = "depends on external API"
+    ENV_VAR         = "depends on environment variable"
+    OBJECT_STATE    = "depends on object state"
+    LOCAL_VAR_GUARD = "local variable guard"
+    ASYNC_FUNCTION  = "async function"
+    INVALID_SYNTAX  = "generator produced invalid syntax"
+    GATE4_FAILURE   = "test failed on correct code — likely false positive"
+    GATE5_FAILURE   = "test passed even with bug injected — wouldn't catch it"
+    SECURITY        = "generated test failed security review"
+    DUPLICATE       = "duplicate of existing test"
+    WEAK_ASSERTION  = "assertion too weak"
+    TOO_SIMILAR     = "too similar to existing test"
+
+
+class GateResult(BaseModel):
+    """Result of a single gate check in the 5-gate pipeline."""
+    passed: bool
+    gate: int                      # 1–5
+    reason: str | None = None      # set when passed=False
+
+
+class ConfidenceTier(StrEnum):
+    """Confidence tier for a WRITTEN test."""
+    HIGH   = "HIGH"    # ≥85 — ship without review
+    MEDIUM = "MEDIUM"  # 60–84 — review recommended
+    LOW    = "LOW"     # <60 — review required; gets # quell: review comment
+
+
+class OutputBucket(StrEnum):
+    """Which bucket a candidate test lands in after the pipeline."""
+    WRITTEN    = "WRITTEN"     # passed all 5 gates
+    SCAFFOLDED = "SCAFFOLDED"  # passed gate 1+2; human assertion needed
+    FLAGGED    = "FLAGGED"     # cannot auto-test; reason always provided
+
+
+class BucketedResult(BaseModel):
+    """Final outcome for one edge-case candidate after the full pipeline."""
+    requirement_id: str
+    bucket: OutputBucket
+    flag_reason: FlagReason | None = None   # set when bucket == FLAGGED
+    gates_passed: int = 0                   # 0–5
+    generated_test: GeneratedTest | None = None
+    confidence_score: int | None = None     # 0–100; set when bucket == WRITTEN
+    confidence_tier: ConfidenceTier | None = None
+    scaffold_file: Path | None = None       # set when bucket == SCAFFOLDED
+    source_file: Path | None = None
+    source_line: int | None = None
+
+
+def confidence_tier_for(score: int) -> ConfidenceTier:
+    """Map a 0–100 confidence score to its tier."""
+    if score >= 85:
+        return ConfidenceTier.HIGH
+    if score >= 60:
+        return ConfidenceTier.MEDIUM
+    return ConfidenceTier.LOW

--- a/tests/unit/test_confidence.py
+++ b/tests/unit/test_confidence.py
@@ -1,0 +1,211 @@
+"""Unit tests for confidence scoring and PRS (spec7 §2.5, §2.6)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quell.core.confidence.badge import generate_badge
+from quell.core.confidence.prs import PRSResult, compute_prs
+from quell.core.confidence.score import ConfidenceContext, ConfidenceResult, compute_confidence
+from quell.core.models import (
+    BucketedResult,
+    ConfidenceTier,
+    FlagReason,
+    GeneratedTest,
+    OutputBucket,
+    SpecSource,
+    confidence_tier_for,
+)
+
+
+def _make_test(generated_by: str = "rule_engine", code: str = "") -> GeneratedTest:
+    return GeneratedTest(
+        requirement_id="req-1",
+        test_function_name="test_x",
+        test_code=code or "import pytest\ndef test_x():\n    pytest.raises(ValueError)\n",
+        test_file_path=Path("tests/test_x.py"),
+        explanation="test",
+        generated_by=generated_by,
+    )
+
+
+def _make_written(confidence: int, tier: ConfidenceTier | None = None) -> BucketedResult:
+    return BucketedResult(
+        requirement_id="req-1",
+        bucket=OutputBucket.WRITTEN,
+        confidence_score=confidence,
+        confidence_tier=tier or confidence_tier_for(confidence),
+        gates_passed=5,
+    )
+
+
+def _make_flagged() -> BucketedResult:
+    return BucketedResult(
+        requirement_id="req-2",
+        bucket=OutputBucket.FLAGGED,
+        flag_reason=FlagReason.EXTERNAL_API,
+    )
+
+
+def _make_scaffolded() -> BucketedResult:
+    return BucketedResult(
+        requirement_id="req-3",
+        bucket=OutputBucket.SCAFFOLDED,
+        gates_passed=2,
+    )
+
+
+# ── ConfidenceScore ───────────────────────────────────────────────────────────
+
+class TestComputeConfidence:
+    def test_pydantic_source_yields_high_score(self):
+        t = _make_test(code="import pytest\ndef test_x():\n    with pytest.raises(ValueError, match='positive'):\n        pass\n")
+        ctx = ConfidenceContext(spec_source=SpecSource.TYPE, covering_test_count=0)
+        result = compute_confidence(t, ctx)
+        assert result.score >= 85
+        assert result.tier == ConfidenceTier.HIGH
+
+    def test_llm_generated_yields_lower_score(self):
+        t = _make_test(generated_by="llm:groq-llama3")
+        ctx = ConfidenceContext(spec_source=SpecSource.CODE_GUARD)
+        result = compute_confidence(t, ctx)
+        assert result.score < 70
+        assert result.tier in (ConfidenceTier.MEDIUM, ConfidenceTier.LOW)
+
+    def test_docstring_source_medium_range(self):
+        t = _make_test(code="import pytest\ndef test_x():\n    pytest.raises(ValueError)\n")
+        ctx = ConfidenceContext(spec_source=SpecSource.DOCSTRING, covering_test_count=0)
+        result = compute_confidence(t, ctx)
+        assert 55 <= result.score <= 100
+
+    def test_covered_path_lowers_uniqueness(self):
+        t = _make_test()
+        ctx_unique = ConfidenceContext(spec_source=SpecSource.TYPE, covering_test_count=0)
+        ctx_overlap = ConfidenceContext(spec_source=SpecSource.TYPE, covering_test_count=5)
+        r_unique = compute_confidence(t, ctx_unique)
+        r_overlap = compute_confidence(t, ctx_overlap)
+        assert r_unique.score > r_overlap.score
+
+    def test_strong_assertion_raises_score(self):
+        strong_code = (
+            "import pytest\ndef test_x(val):\n"
+            "    with pytest.raises(ValueError, match='must be positive'):\n"
+            "        fn(val)\n"
+        )
+        weak_code = "import pytest\ndef test_x(val):\n    pytest.raises(ValueError)\n"
+        ctx = ConfidenceContext(spec_source=SpecSource.CODE_GUARD, covering_test_count=0)
+        r_strong = compute_confidence(_make_test(code=strong_code), ctx)
+        r_weak = compute_confidence(_make_test(code=weak_code), ctx)
+        assert r_strong.score >= r_weak.score
+
+    def test_score_clamped_0_100(self):
+        t = _make_test()
+        ctx = ConfidenceContext()
+        result = compute_confidence(t, ctx)
+        assert 0 <= result.score <= 100
+
+    def test_result_has_all_factors(self):
+        t = _make_test()
+        ctx = ConfidenceContext(spec_source=SpecSource.TYPE)
+        result = compute_confidence(t, ctx)
+        assert "spec_source" in result.factors
+        assert "violation" in result.factors
+        assert "assertion" in result.factors
+        assert "uniqueness" in result.factors
+
+
+# ── PRS ───────────────────────────────────────────────────────────────────────
+
+class TestComputePRS:
+    def test_empty_results(self):
+        prs = compute_prs([])
+        assert prs.score == 0
+        assert prs.tier == "red"
+
+    def test_all_written_high_confidence(self):
+        results = [_make_written(90)] * 5
+        prs = compute_prs(results)
+        assert prs.tier == "green"
+        assert prs.score >= 80
+        assert prs.written_count == 5
+        assert prs.flagged_count == 0
+
+    def test_all_flagged_gives_low_prs(self):
+        results = [_make_flagged()] * 10
+        prs = compute_prs(results)
+        assert prs.score == 0
+        assert prs.tier == "red"
+        assert prs.flagged_count == 10
+
+    def test_mixed_results(self):
+        results = [_make_written(88)] * 3 + [_make_flagged()] * 2 + [_make_scaffolded()]
+        prs = compute_prs(results)
+        assert prs.written_count == 3
+        assert prs.scaffolded_count == 1
+        assert prs.flagged_count == 2
+        assert 0 <= prs.score <= 100
+
+    def test_edge_case_coverage_pct(self):
+        results = [_make_written(85)] * 2 + [_make_scaffolded()] + [_make_flagged()] * 2
+        prs = compute_prs(results)
+        # 2 written + 1 scaffolded = 3 handled out of 5
+        assert abs(prs.edge_case_coverage_pct - 60.0) < 0.01
+
+    def test_tier_boundaries(self):
+        high_results = [_make_written(95)] * 10
+        low_results = [_make_flagged()] * 8 + [_make_written(95)] * 2
+        prs_high = compute_prs(high_results)
+        prs_low = compute_prs(low_results)
+        assert prs_high.tier == "green"
+        assert prs_low.tier in ("red", "yellow")
+
+    def test_avg_confidence_computed(self):
+        results = [_make_written(80), _make_written(90)]
+        prs = compute_prs(results)
+        assert abs(prs.avg_written_confidence - 85.0) < 0.01
+
+    def test_tier_labels(self):
+        from quell.core.confidence.prs import _tier
+        assert _tier(80) == ("green", "Production Ready")
+        assert _tier(65) == ("yellow", "Review Needed")
+        assert _tier(40) == ("red", "Edge Cases Uncovered")
+
+
+# ── Badge ─────────────────────────────────────────────────────────────────────
+
+class TestGenerateBadge:
+    def test_returns_svg_string(self):
+        svg = generate_badge(84)
+        assert svg.startswith("<svg")
+        assert "</svg>" in svg
+
+    def test_score_in_badge(self):
+        svg = generate_badge(84)
+        assert "84%" in svg
+
+    def test_green_for_high_score(self):
+        svg = generate_badge(80)
+        assert "#4c1" in svg
+
+    def test_yellow_for_medium_score(self):
+        svg = generate_badge(65)
+        assert "#dfb317" in svg
+
+    def test_red_for_low_score(self):
+        svg = generate_badge(40)
+        assert "#e05d44" in svg
+
+    def test_score_clamped(self):
+        svg_over = generate_badge(150)
+        assert "100%" in svg_over
+        svg_under = generate_badge(-10)
+        assert "0%" in svg_under
+
+    def test_explicit_tier_override(self):
+        svg = generate_badge(50, tier="green")
+        assert "#4c1" in svg
+
+    def test_quell_prs_label(self):
+        svg = generate_badge(75)
+        assert "Quell PRS" in svg

--- a/tests/unit/test_gates.py
+++ b/tests/unit/test_gates.py
@@ -1,0 +1,217 @@
+"""Unit tests for the 5-gate verification pipeline (spec7 §2.4)."""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from quell.core.gates.gate1_ast import GateContext, check as gate1
+from quell.core.gates.gate2_originality import check as gate2
+from quell.core.gates.gate3_security import check as gate3
+from quell.core.models import (
+    BucketedResult,
+    ConfidenceTier,
+    FlagReason,
+    GateResult,
+    OutputBucket,
+    confidence_tier_for,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+_VALID_TEST = textwrap.dedent("""\
+    import pytest
+
+    def test_example():
+        assert 1 + 1 == 2
+""")
+
+_EMPTY_CTX = GateContext()
+
+
+# ── Gate 1 ────────────────────────────────────────────────────────────────────
+
+class TestGate1:
+    def test_valid_python_passes(self):
+        result = gate1(_VALID_TEST, _EMPTY_CTX)
+        assert result.passed
+        assert result.gate == 1
+
+    def test_syntax_error_fails(self):
+        result = gate1("def broken(:\n    pass\n", _EMPTY_CTX)
+        assert not result.passed
+        assert result.gate == 1
+        assert "invalid syntax" in (result.reason or "")
+
+    def test_unresolvable_import_fails(self):
+        bad = "import totally_nonexistent_package_xyz\n\ndef test_x(): pass\n"
+        result = gate1(bad, _EMPTY_CTX)
+        assert not result.passed
+        assert "unresolvable import" in (result.reason or "")
+
+    def test_stdlib_import_passes(self):
+        code = "import json\nimport pathlib\n\ndef test_x():\n    assert True\n"
+        result = gate1(code, _EMPTY_CTX)
+        assert result.passed
+
+    def test_pytest_import_passes(self):
+        result = gate1(_VALID_TEST, _EMPTY_CTX)
+        assert result.passed
+
+
+# ── Gate 2 ────────────────────────────────────────────────────────────────────
+
+class TestGate2:
+    def test_novel_test_passes(self):
+        result = gate2(_VALID_TEST, _EMPTY_CTX)
+        assert result.passed
+        assert result.gate == 2
+
+    def test_boilerplate_assertion_fails(self):
+        code = textwrap.dedent("""\
+            def test_boilerplate():
+                result = some_func()
+                assert result is not None
+        """)
+        result = gate2(code, _EMPTY_CTX)
+        assert not result.passed
+        assert result.gate == 2
+        assert "weak" in (result.reason or "")
+
+    def test_duplicate_name_fails(self, tmp_path):
+        existing = tmp_path / "test_existing.py"
+        existing.write_text("def test_example():\n    assert 1 == 1\n", encoding="utf-8")
+        ctx = GateContext(existing_test_files=[str(existing)])
+        result = gate2(_VALID_TEST, ctx)
+        assert not result.passed
+        assert "duplicate" in (result.reason or "")
+
+    def test_no_existing_files_passes(self):
+        ctx = GateContext(existing_test_files=[])
+        result = gate2(_VALID_TEST, ctx)
+        assert result.passed
+
+
+# ── Gate 3 ────────────────────────────────────────────────────────────────────
+
+class TestGate3:
+    def test_clean_test_passes(self):
+        result = gate3(_VALID_TEST, _EMPTY_CTX)
+        assert result.passed
+        assert result.gate == 3
+
+    def test_eval_call_fails(self):
+        code = "def test_x():\n    eval('1+1')\n    assert True\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "eval" in (result.reason or "")
+
+    def test_exec_call_fails(self):
+        code = "def test_x():\n    exec('x=1')\n    assert True\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "exec" in (result.reason or "")
+
+    def test_os_system_fails(self):
+        code = "import os\ndef test_x():\n    os.system('ls')\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "os.system" in (result.reason or "")
+
+    def test_unmocked_requests_fails(self):
+        code = "import requests\ndef test_x():\n    requests.get('http://example.com')\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "network" in (result.reason or "")
+
+    def test_hardcoded_password_fails(self):
+        code = "def test_x():\n    password = 'supersecret123'\n    assert True\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "credential" in (result.reason or "")
+
+    def test_env_mutation_fails(self):
+        code = "import os\ndef test_x():\n    os.environ['SECRET'] = 'val'\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "environ" in (result.reason or "")
+
+    def test_httpx_unmocked_fails(self):
+        code = "import httpx\ndef test_x():\n    httpx.get('http://example.com')\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+
+    def test_subprocess_shell_true_fails(self):
+        code = "import subprocess\ndef test_x():\n    subprocess.Popen(['ls'], shell=True)\n"
+        result = gate3(code, _EMPTY_CTX)
+        assert not result.passed
+        assert "shell=True" in (result.reason or "")
+
+
+# ── Models ────────────────────────────────────────────────────────────────────
+
+class TestV2Models:
+    def test_gate_result_passed(self):
+        gr = GateResult(passed=True, gate=1)
+        assert gr.passed
+        assert gr.gate == 1
+        assert gr.reason is None
+
+    def test_gate_result_failed(self):
+        gr = GateResult(passed=False, gate=3, reason="security issue")
+        assert not gr.passed
+        assert gr.reason == "security issue"
+
+    def test_flag_reason_values(self):
+        assert FlagReason.EXTERNAL_API == "depends on external API"
+        assert FlagReason.GATE4_FAILURE == "test failed on correct code — likely false positive"
+        assert FlagReason.GATE5_FAILURE == "test passed even with bug injected — wouldn't catch it"
+        assert FlagReason.SECURITY == "generated test failed security review"
+
+    def test_output_bucket_values(self):
+        assert OutputBucket.WRITTEN == "WRITTEN"
+        assert OutputBucket.SCAFFOLDED == "SCAFFOLDED"
+        assert OutputBucket.FLAGGED == "FLAGGED"
+
+    def test_confidence_tier_for(self):
+        assert confidence_tier_for(90) == ConfidenceTier.HIGH
+        assert confidence_tier_for(85) == ConfidenceTier.HIGH
+        assert confidence_tier_for(84) == ConfidenceTier.MEDIUM
+        assert confidence_tier_for(60) == ConfidenceTier.MEDIUM
+        assert confidence_tier_for(59) == ConfidenceTier.LOW
+        assert confidence_tier_for(0) == ConfidenceTier.LOW
+
+    def test_bucketed_result_written(self):
+        from quell.core.models import GeneratedTest
+        from pathlib import Path
+        gt = GeneratedTest(
+            requirement_id="req-1",
+            test_function_name="test_positive",
+            test_code="def test_positive(): assert True",
+            test_file_path=Path("tests/test_x.py"),
+            explanation="tests boundary",
+            generated_by="rule_engine",
+        )
+        br = BucketedResult(
+            requirement_id="req-1",
+            bucket=OutputBucket.WRITTEN,
+            gates_passed=5,
+            generated_test=gt,
+            confidence_score=88,
+            confidence_tier=ConfidenceTier.HIGH,
+        )
+        assert br.bucket == OutputBucket.WRITTEN
+        assert br.flag_reason is None
+        assert br.confidence_score == 88
+
+    def test_bucketed_result_flagged(self):
+        br = BucketedResult(
+            requirement_id="req-2",
+            bucket=OutputBucket.FLAGGED,
+            flag_reason=FlagReason.EXTERNAL_API,
+            gates_passed=2,
+            source_file=None,
+        )
+        assert br.bucket == OutputBucket.FLAGGED
+        assert br.flag_reason == FlagReason.EXTERNAL_API
+        assert br.generated_test is None


### PR DESCRIPTION
## Summary

Implements spec7 §2.5 and §2.6 — confidence scoring and Production Readiness Score.

### Changes

- `quell/core/confidence/score.py`: `compute_confidence()` with 4 weighted factors: spec source quality (35%), violation specificity (25%), assertion strength (25%), coverage uniqueness (15%). Returns `ConfidenceResult` with tier breakdown.
- `quell/core/confidence/prs.py`: `compute_prs()` — Production Readiness Score from `BucketedResult` list. Modifiers: +5 if all FLAGGED have `# quell: flagged` justification, -10 if a HIGH test is skipped. Tier labels green/yellow/red.
- `quell/core/confidence/badge.py`: `generate_badge(prs)` — shields.io-style SVG with colour by tier.
- `tests/unit/test_confidence.py`: 23 unit tests (7 score, 8 PRS, 8 badge).

## Test plan

- [x] `pytest tests/unit/test_confidence.py` — 23 tests, all pass
- [x] `ruff check quell/` — clean

Closes #48, #49, #50
Milestone: v2.0.0