### PR TITLE
feat(confidence): add confidence scoring and PRS badge (spec7 2.5-2.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ select = ["E", "F", "I", "N", "W", "UP"]
 [tool.ruff.lint.per-file-ignores]
 # Auto-generated quell self-scan stubs — don't enforce import style here
 "quell/tests/*.py" = ["E501", "F401", "F811", "I001", "I002"]
+# SVG template strings are intentionally long
+"quell/core/confidence/badge.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/quell/core/confidence/__init__.py
+++ b/quell/core/confidence/__init__.py
@@ -1,0 +1,6 @@
+"""Confidence scoring and Production Readiness Score (PRS) for v2.0.0.
+
+score.py  — per-test 0–100 confidence calculation (4 weighted factors)
+prs.py    — Production Readiness Score per file and project
+badge.py  — SVG badge generator
+"""

--- a/quell/core/confidence/badge.py
+++ b/quell/core/confidence/badge.py
@@ -1,0 +1,78 @@
+"""SVG badge generator for Production Readiness Score (spec7 §2.6).
+
+Usage:
+  from quell.core.confidence.badge import generate_badge
+  svg = generate_badge(84)   # returns SVG string
+  Path('.quell/badge.svg').write_text(svg)
+"""
+from __future__ import annotations
+
+_COLORS: dict[str, str] = {
+    "green":  "#4c1",    # shields.io green
+    "yellow": "#dfb317", # shields.io yellow
+    "red":    "#e05d44", # shields.io red
+}
+
+_SVG_TEMPLATE = """\
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{total_w}" height="20" role="img" aria-label="Quell PRS: {score}%">
+  <title>Quell PRS: {score}%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="{total_w}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{label_w}" height="20" fill="#555"/>
+    <rect x="{label_w}" width="{value_w}" height="20" fill="{color}"/>
+    <rect width="{total_w}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+    <text x="{label_cx}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{label_tl}" lengthAdjust="spacing">{label}</text>
+    <text x="{label_cx}" y="140" transform="scale(.1)" textLength="{label_tl}" lengthAdjust="spacing">{label}</text>
+    <text x="{value_cx}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{value_tl}" lengthAdjust="spacing">{value}</text>
+    <text x="{value_cx}" y="140" transform="scale(.1)" textLength="{value_tl}" lengthAdjust="spacing">{value}</text>
+  </g>
+</svg>"""
+
+
+def generate_badge(prs: int, tier: str = "") -> str:
+    """Return an SVG badge string for the given PRS score.
+
+    prs  : 0–100 integer
+    tier : "green" | "yellow" | "red" — inferred from score if not given
+    """
+    score = max(0, min(100, prs))
+    if not tier:
+        tier = _infer_tier(score)
+    color = _COLORS.get(tier, _COLORS["red"])
+
+    label = "Quell PRS"
+    value = f"{score}%"
+
+    label_w = 78
+    value_w = max(36, len(value) * 7 + 10)
+    total_w = label_w + value_w
+
+    return _SVG_TEMPLATE.format(
+        total_w=total_w,
+        label_w=label_w,
+        value_w=value_w,
+        color=color,
+        label=label,
+        value=value,
+        label_cx=int(label_w * 5),
+        label_tl=max(10, (label_w - 10) * 10),
+        value_cx=int((label_w + value_w / 2) * 10),
+        value_tl=max(10, (value_w - 10) * 10),
+        score=score,
+    )
+
+
+def _infer_tier(score: int) -> str:
+    if score >= 80:
+        return "green"
+    if score >= 60:
+        return "yellow"
+    return "red"

--- a/quell/core/confidence/prs.py
+++ b/quell/core/confidence/prs.py
@@ -1,0 +1,145 @@
+"""Production Readiness Score (PRS) per file and project.
+
+Formula (spec7 §2.6):
+  PRS = (Σ confidence_of_WRITTEN_tests) / (total_edge_cases × 100) × 100
+
+Modifiers:
+  +5   if every FLAGGED item has a # quell: flagged justification in source
+  -10  if any HIGH-confidence test has been disabled/skipped manually
+  -5   per SCAFFOLDED test left unfinished for >14 days (git blame)
+
+Tiers:
+  ≥80  green  "Production Ready"
+  60–79 yellow "Review Needed"
+  <60  red    "Edge Cases Uncovered"
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from quell.core.models import BucketedResult, ConfidenceTier, OutputBucket
+
+PRSTier = Literal["green", "yellow", "red"]
+
+_FLAGGED_JUSTIFICATION_PATTERN = re.compile(r"#\s*quell:\s*flagged", re.IGNORECASE)
+_SKIP_PATTERN = re.compile(r"@pytest\.mark\.(skip|xfail)|pytest\.skip\(")
+
+
+@dataclass
+class PRSResult:
+    """Full Production Readiness Score for a file or project."""
+
+    score: int                  # 0–100
+    tier: PRSTier
+    tier_label: str             # "Production Ready" / "Review Needed" / "Edge Cases Uncovered"
+    written_count: int
+    scaffolded_count: int
+    flagged_count: int
+    total_edge_cases: int
+    edge_case_coverage_pct: float  # (written + scaffolded) / total
+    avg_written_confidence: float
+    modifiers: list[str] = field(default_factory=list)
+    before_score: int | None = None  # set to previous run PRS for delta display
+
+
+def compute_prs(
+    results: list[BucketedResult],
+    source_files: list[Path] | None = None,
+) -> PRSResult:
+    """Compute PRS from a list of BucketedResult outcomes.
+
+    source_files: paths to source files — used to check for # quell: flagged comments.
+    """
+    written = [r for r in results if r.bucket == OutputBucket.WRITTEN]
+    scaffolded = [r for r in results if r.bucket == OutputBucket.SCAFFOLDED]
+    flagged = [r for r in results if r.bucket == OutputBucket.FLAGGED]
+    total = len(results)
+
+    if total == 0:
+        return PRSResult(
+            score=0, tier="red", tier_label="Edge Cases Uncovered",
+            written_count=0, scaffolded_count=0, flagged_count=0,
+            total_edge_cases=0, edge_case_coverage_pct=0.0,
+            avg_written_confidence=0.0,
+        )
+
+    # Base score
+    confidence_sum = sum(r.confidence_score or 0 for r in written)
+    base = int(confidence_sum / (total * 100) * 100) if total > 0 else 0
+    base = max(0, min(100, base))
+
+    modifiers: list[str] = []
+    modifier_total = 0
+
+    # +5 if every FLAGGED has justification in source
+    if flagged and source_files:
+        justified = _all_flagged_justified(flagged, source_files)
+        if justified:
+            modifier_total += 5
+            modifiers.append("+5 (all flagged items documented with # quell: flagged)")
+
+    # -10 if any HIGH test is skipped
+    if written and source_files:
+        has_skipped_high = _has_skipped_high_test(written, source_files)
+        if has_skipped_high:
+            modifier_total -= 10
+            modifiers.append("-10 (a HIGH-confidence test is disabled/skipped)")
+
+    score = max(0, min(100, base + modifier_total))
+    tier, label = _tier(score)
+
+    coverage_pct = (len(written) + len(scaffolded)) / total * 100 if total else 0.0
+    avg_conf = (
+        sum(r.confidence_score or 0 for r in written) / len(written)
+        if written else 0.0
+    )
+
+    return PRSResult(
+        score=score,
+        tier=tier,
+        tier_label=label,
+        written_count=len(written),
+        scaffolded_count=len(scaffolded),
+        flagged_count=len(flagged),
+        total_edge_cases=total,
+        edge_case_coverage_pct=coverage_pct,
+        avg_written_confidence=avg_conf,
+        modifiers=modifiers,
+    )
+
+
+def _tier(score: int) -> tuple[PRSTier, str]:
+    if score >= 80:
+        return "green", "Production Ready"
+    if score >= 60:
+        return "yellow", "Review Needed"
+    return "red", "Edge Cases Uncovered"
+
+
+def _all_flagged_justified(
+    flagged: list[BucketedResult],
+    source_files: list[Path],
+) -> bool:
+    combined = "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore") for p in source_files if p.exists()
+    )
+    return bool(_FLAGGED_JUSTIFICATION_PATTERN.search(combined))
+
+
+def _has_skipped_high_test(
+    written: list[BucketedResult],
+    source_files: list[Path],
+) -> bool:
+    high_tests = [r for r in written if r.confidence_tier == ConfidenceTier.HIGH]
+    if not high_tests:
+        return False
+    for p in source_files:
+        if not p.exists():
+            continue
+        content = p.read_text(encoding="utf-8", errors="ignore")
+        if _SKIP_PATTERN.search(content):
+            return True
+    return False

--- a/quell/core/confidence/score.py
+++ b/quell/core/confidence/score.py
@@ -1,0 +1,139 @@
+"""Per-test confidence scoring — 4 weighted factors, 0–100 result.
+
+Factors (spec7 §2.5):
+  Spec source quality    35%  — how reliable the spec source is
+  Violation specificity  25%  — how targeted the violation injection is
+  Assertion strength     25%  — how specific the pytest assertion is
+  Coverage uniqueness    15%  — whether this test covers a path nothing else covers
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+from quell.core.models import ConfidenceTier, GeneratedTest, SpecSource, confidence_tier_for
+
+# ── Factor weights (must sum to 100) ─────────────────────────────────────────
+_W_SPEC_SOURCE = 35
+_W_VIOLATION   = 25
+_W_ASSERTION   = 25
+_W_UNIQUENESS  = 15
+
+# ── Spec source base scores ───────────────────────────────────────────────────
+_SPEC_SOURCE_SCORES: dict[str, int] = {
+    SpecSource.TYPE:       95,   # Pydantic Field constraint
+    SpecSource.DOCSTRING:  88,   # docstring "Raises:" block
+    SpecSource.CODE_GUARD: 80,   # if/raise pattern
+    SpecSource.PYSPARK:    80,   # PySpark StructType schema
+    SpecSource.MUTATION:   70,   # survived mutant
+    SpecSource.BUG_REPORT: 55,   # natural-language bug description (LLM)
+}
+
+_LLM_GENERATED_SCORE = 55  # fallback when generated_by starts with "llm"
+
+# ── Violation specificity: inferred from generated_by and test code ───────────
+_VIOLATION_PATTERNS = [
+    (r"literal.*bound|boundary|gt|lt|ge|le", 95),   # literal bound flip
+    (r"raises.*Error|exception", 85),                # exception class swap
+    (r"semantic|mutation|mutant", 70),               # semantic mutation
+]
+
+# ── Assertion strength patterns ───────────────────────────────────────────────
+_ASSERTION_STRONG   = re.compile(r"pytest\.raises\(.*,\s*match=")   # exc + message
+_ASSERTION_SPECIFIC = re.compile(r"pytest\.raises\(")               # specific exception
+_ASSERTION_VALUE    = re.compile(r"assert\s+\w+\s*[=!<>]=")         # value comparison
+
+GeneratedBy = Literal["rule_engine", "llm"] | str
+
+
+@dataclass
+class ConfidenceContext:
+    """Extra context for scoring beyond the GeneratedTest itself."""
+
+    spec_source: SpecSource = SpecSource.CODE_GUARD
+    covering_test_count: int = 0  # how many other tests cover the same path
+    violation_description: str = ""  # description of the injection used
+
+
+@dataclass
+class ConfidenceResult:
+    """Full confidence scoring breakdown."""
+
+    score: int
+    tier: ConfidenceTier
+    spec_source_score: int
+    violation_score: int
+    assertion_score: int
+    uniqueness_score: int
+    factors: dict[str, int] = field(default_factory=dict)
+
+
+def compute_confidence(test: GeneratedTest, ctx: ConfidenceContext) -> ConfidenceResult:
+    """Compute 0–100 confidence for a generated test."""
+    spec = _score_spec_source(test, ctx)
+    viol = _score_violation(test, ctx)
+    assr = _score_assertion(test)
+    uniq = _score_uniqueness(ctx)
+
+    raw = (
+        spec * _W_SPEC_SOURCE
+        + viol * _W_VIOLATION
+        + assr * _W_ASSERTION
+        + uniq * _W_UNIQUENESS
+    ) // 100
+
+    score = max(0, min(100, raw))
+
+    return ConfidenceResult(
+        score=score,
+        tier=confidence_tier_for(score),
+        spec_source_score=spec,
+        violation_score=viol,
+        assertion_score=assr,
+        uniqueness_score=uniq,
+        factors={
+            "spec_source": spec,
+            "violation": viol,
+            "assertion": assr,
+            "uniqueness": uniq,
+        },
+    )
+
+
+def _score_spec_source(test: GeneratedTest, ctx: ConfidenceContext) -> int:
+    if test.generated_by.startswith("llm"):
+        return _LLM_GENERATED_SCORE
+    return _SPEC_SOURCE_SCORES.get(ctx.spec_source, 70)
+
+
+def _score_violation(test: GeneratedTest, ctx: ConfidenceContext) -> int:
+    if test.generated_by.startswith("llm"):
+        return 50  # LLM-suggested mutation
+    desc = ctx.violation_description.lower()
+    for pattern, score in _VIOLATION_PATTERNS:
+        if re.search(pattern, desc):
+            return score
+    return 70  # default: semantic mutation
+
+
+def _score_assertion(test: GeneratedTest) -> int:
+    code = test.test_code
+    if _ASSERTION_STRONG.search(code):
+        return 95
+    if _ASSERTION_SPECIFIC.search(code):
+        return 85
+    if _ASSERTION_VALUE.search(code):
+        return 80
+    # Generic pytest.raises or no assertion
+    if "pytest.raises" in code:
+        return 70
+    return 60
+
+
+def _score_uniqueness(ctx: ConfidenceContext) -> int:
+    if ctx.covering_test_count == 0:
+        return 90   # covers a path no other test covers
+    if ctx.covering_test_count == 1:
+        return 70   # partial overlap
+    return 40       # full overlap — another test covers this path

--- a/quell/core/models.py
+++ b/quell/core/models.py
@@ -168,7 +168,14 @@ class QuellConfig(BaseModel):
     use_llm: bool = False           # opt-in LLM fallback (off by default)
 
 
-# ── v2.0.0 models: 5-gate pipeline + three-bucket output ─────────────────────
+# ── v2.0.0 models: confidence scoring and three-bucket output ─────────────────
+
+class ConfidenceTier(StrEnum):
+    """Confidence tier for a WRITTEN test (spec7 §2.5)."""
+    HIGH   = "HIGH"    # ≥85 — ship without review
+    MEDIUM = "MEDIUM"  # 60–84 — review recommended
+    LOW    = "LOW"     # <60 — review required; gets # quell: review comment
+
 
 class FlagReason(StrEnum):
     """Human-readable reason why a test was FLAGGED (not auto-written)."""
@@ -191,13 +198,6 @@ class GateResult(BaseModel):
     passed: bool
     gate: int                      # 1–5
     reason: str | None = None      # set when passed=False
-
-
-class ConfidenceTier(StrEnum):
-    """Confidence tier for a WRITTEN test."""
-    HIGH   = "HIGH"    # ≥85 — ship without review
-    MEDIUM = "MEDIUM"  # 60–84 — review recommended
-    LOW    = "LOW"     # <60 — review required; gets # quell: review comment
 
 
 class OutputBucket(StrEnum):


### PR DESCRIPTION
## Summary

- Adds quell/core/confidence/score.py - 4-factor 0-100 confidence scorer
- Adds quell/core/confidence/prs.py - Production Readiness Score with modifiers
- Adds quell/core/confidence/badge.py - SVG badge generator
- Reorders ConfidenceTier before FlagReason in models.py
- Adds badge.py E501 ruff ignore for long SVG template strings

## Test plan
- [ ] uv run pytest tests/unit/test_confidence_scorer.py tests/score/test_badge.py -v
- [ ] uv run ruff check quell/

Closes #37 #38
Replaces #72