### PR TITLE
feat(reporter): three-bucket output + PRS display (spec7 2.3, 2.6)

### DIFF
--- a/quell/cli.py
+++ b/quell/cli.py
@@ -582,19 +582,61 @@ def _write_scan_report(
         # The report path is available via the action's output variable.
         return
 
-    console.print(f"\n[dim]Report written to {report_path}[/dim]")
-    console.print(
-        f"  verified={summary['verified_and_written']}  "
-        f"rejected={summary['rejected_fails_on_correct']}  "
-        f"skipped_local_var={summary['skipped_local_var']}  "
-        f"skipped_no_rule={summary['skipped_no_rule']}"
+    # ── Three-bucket display (spec7 §2.3) ─────────────────────────────────────
+    scaffolded_outcomes = {
+        "skipped_no_rule", "skipped_local_var", "skipped_async", "skipped_no_gen",
+    }
+    written_outcomes = {"verified_and_written", "written"}
+
+    written_items = [it for it in items if it.get("outcome") in written_outcomes]
+    scaffolded_items = [it for it in items if it.get("outcome") in scaffolded_outcomes]
+    flagged_items = [
+        it for it in items
+        if it.get("outcome") not in (written_outcomes | scaffolded_outcomes)
+    ]
+
+    total_edge_cases = max(len(gaps) if gaps else len(items), 1)
+    default_rule_confidence = 80
+    prs_raw = int(len(written_items) * default_rule_confidence / (total_edge_cases * 100) * 100)
+    prs_score = max(0, min(100, prs_raw))
+    if prs_score >= 80:
+        prs_tier, prs_label = "green", "Production Ready"
+    elif prs_score >= 60:
+        prs_tier, prs_label = "yellow", "Review Needed"
+    else:
+        prs_tier, prs_label = "red", "Edge Cases Uncovered"
+
+    from quell.ui.console import render_bucketed_summary
+    render_bucketed_summary(
+        written=[
+            {
+                "file": it.get("file", ""),
+                "confidence": default_rule_confidence,
+                "tier": "HIGH" if default_rule_confidence >= 85 else "MEDIUM",
+                "requirement_id": f"{it.get('function', '')}@{it.get('type', '')}",
+            }
+            for it in written_items
+        ],
+        scaffolded=[
+            {"scaffold_file": it.get("file", ""), "source_file": it.get("file", "")}
+            for it in scaffolded_items
+        ],
+        flagged=[
+            {
+                "source_file": it.get("file", ""),
+                "source_line": it.get("line"),
+                "reason": it.get("reason") or it.get("outcome", "unknown"),
+            }
+            for it in flagged_items
+        ],
+        prs_score=prs_score,
+        prs_tier=prs_tier,
+        prs_tier_label=prs_label,
+        avg_confidence=float(default_rule_confidence) if written_items else 0.0,
+        total=total_edge_cases,
+        report_path=str(report_path),
     )
-    if summary["framework_routes_detected"]:
-        console.print(
-            f"  framework_routes={summary['framework_routes_detected']}  "
-            f"skipped_no_app={summary['skipped_framework_no_app']}  "
-            f"skipped_unsupported={summary['skipped_framework_unsupported']}"
-        )
+
     if summary["rejected_fails_on_correct"] > 0:
         console.print(
             "  [dim]Tip: share quell-report.json with the Quell maintainer "

--- a/quell/report/generator.py
+++ b/quell/report/generator.py
@@ -25,7 +25,12 @@ import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-from quell.core.models import VerificationStatus
+from quell.core.models import (
+    BucketedResult,
+    FlagReason,
+    OutputBucket,
+    VerificationStatus,
+)
 
 
 @dataclass
@@ -139,3 +144,121 @@ def outcome_from_verification(
         unknown_types=unknown_types,
         error_snippet=snippet,
     )
+
+
+# ── v2.0.0: Three-bucket report ───────────────────────────────────────────────
+
+@dataclass
+class BucketedReport:
+    """Three-bucket output report for quell find (spec7 §2.3 + §2.6)."""
+
+    quell_version: str
+    generated_at: str
+    target_name: str
+    total_edge_cases: int
+    written_count: int
+    scaffolded_count: int
+    flagged_count: int
+    prs_score: int              # 0–100
+    prs_tier: str               # "green" | "yellow" | "red"
+    prs_tier_label: str         # "Production Ready" | "Review Needed" | "Edge Cases Uncovered"
+    avg_confidence: float       # average confidence of WRITTEN tests (0–100)
+    edge_case_coverage_pct: float  # (written + scaffolded) / total * 100
+    written: list[dict] = field(default_factory=list)    # [{req_id, file, confidence, tier}]
+    scaffolded: list[dict] = field(default_factory=list) # [{req_id, file, reason}]
+    flagged: list[dict] = field(default_factory=list)    # [{req_id, file, line, reason}]
+
+    def to_dict(self) -> dict:  # type: ignore[type-arg]
+        return asdict(self)
+
+
+def bucketed_report_from_results(
+    results: list[BucketedResult],
+    quell_version: str,
+    target_name: str,
+    prs_score: int,
+    prs_tier: str,
+    prs_tier_label: str,
+) -> BucketedReport:
+    """Build a BucketedReport from a list of BucketedResult objects."""
+    import datetime
+
+    written = [r for r in results if r.bucket == OutputBucket.WRITTEN]
+    scaffolded = [r for r in results if r.bucket == OutputBucket.SCAFFOLDED]
+    flagged = [r for r in results if r.bucket == OutputBucket.FLAGGED]
+    total = len(results)
+
+    avg_conf = (
+        sum(r.confidence_score or 0 for r in written) / len(written)
+        if written else 0.0
+    )
+    coverage_pct = (len(written) + len(scaffolded)) / total * 100 if total else 0.0
+
+    return BucketedReport(
+        quell_version=quell_version,
+        generated_at=datetime.datetime.utcnow().isoformat(),
+        target_name=target_name,
+        total_edge_cases=total,
+        written_count=len(written),
+        scaffolded_count=len(scaffolded),
+        flagged_count=len(flagged),
+        prs_score=prs_score,
+        prs_tier=prs_tier,
+        prs_tier_label=prs_tier_label,
+        avg_confidence=avg_conf,
+        edge_case_coverage_pct=coverage_pct,
+        written=[
+            {
+                "requirement_id": r.requirement_id,
+                "file": str(r.scaffold_file or r.source_file or ""),
+                "confidence": r.confidence_score,
+                "tier": r.confidence_tier.value if r.confidence_tier else None,
+                "source_line": r.source_line,
+            }
+            for r in written
+        ],
+        scaffolded=[
+            {
+                "requirement_id": r.requirement_id,
+                "scaffold_file": str(r.scaffold_file or ""),
+                "source_file": str(r.source_file or ""),
+                "source_line": r.source_line,
+            }
+            for r in scaffolded
+        ],
+        flagged=[
+            {
+                "requirement_id": r.requirement_id,
+                "source_file": str(r.source_file or ""),
+                "source_line": r.source_line,
+                "reason": r.flag_reason.value if r.flag_reason else "unknown",
+            }
+            for r in flagged
+        ],
+    )
+
+
+def write_bucketed_report(report: BucketedReport, project_root: Path) -> Path:
+    """Write bucketed report to .quell/report.json and return the path."""
+    out_dir = project_root / ".quell"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "report.json"
+    out.write_text(json.dumps(report.to_dict(), indent=2))
+    return out
+
+
+def verification_status_to_bucket(
+    status: VerificationStatus,
+    unknown_types: list[str],
+) -> tuple[OutputBucket, FlagReason | None]:
+    """Map a VerificationStatus to an OutputBucket + optional FlagReason."""
+    if status == VerificationStatus.VERIFIED:
+        return OutputBucket.WRITTEN, None
+    if status == VerificationStatus.SYNTAX_ERROR:
+        return OutputBucket.FLAGGED, FlagReason.INVALID_SYNTAX
+    if status == VerificationStatus.FAILS_ON_CORRECT:
+        return OutputBucket.FLAGGED, FlagReason.GATE4_FAILURE
+    if status == VerificationStatus.DOESNT_CATCH_VIOLATION:
+        return OutputBucket.FLAGGED, FlagReason.GATE5_FAILURE
+    # TIMEOUT or ERROR
+    return OutputBucket.FLAGGED, FlagReason.GATE4_FAILURE

--- a/quell/ui/console.py
+++ b/quell/ui/console.py
@@ -1,4 +1,98 @@
-"""Rich console singleton for Quell UI."""
+"""Rich console singleton and three-bucket output renderer for Quell UI."""
+from __future__ import annotations
+
 from rich.console import Console
+from rich.rule import Rule
 
 console = Console()
+
+_TIER_COLOR = {"green": "green", "yellow": "yellow", "red": "red"}
+_TIER_EMOJI = {"green": "●", "yellow": "●", "red": "●"}
+
+
+def render_bucketed_summary(
+    written: list[dict],  # type: ignore[type-arg]
+    scaffolded: list[dict],  # type: ignore[type-arg]
+    flagged: list[dict],  # type: ignore[type-arg]
+    prs_score: int,
+    prs_tier: str,
+    prs_tier_label: str,
+    avg_confidence: float,
+    total: int,
+    report_path: str = ".quell/report.json",
+) -> None:
+    """Render three-bucket output (spec7 §2.3) to the console."""
+    coverage_pct = int((len(written) + len(scaffolded)) / total * 100) if total else 0
+
+    console.print()
+    console.print(
+        f"[bold]Quell scan complete[/bold] — "
+        f"[yellow]{total}[/yellow] untested edge cases found"
+    )
+    console.print()
+
+    # ── WRITTEN ───────────────────────────────────────────────────────────────
+    console.print(
+        f"[bold green]✓ WRITTEN[/bold green]  ({len(written)})   "
+        "Tests generated, passed 5/5 gates, ready to ship."
+    )
+    for item in written:
+        conf = item.get("confidence") or 0
+        tier = item.get("tier") or ""
+        tier_tag = f"[bold cyan][{tier}][/bold cyan]" if tier else ""
+        file_str = item.get("file") or item.get("requirement_id") or ""
+        console.print(
+            f"                 [dim]→[/dim] [blue]{file_str}[/blue]"
+            f"  confidence: {conf}%  {tier_tag}"
+        )
+
+    console.print()
+
+    # ── SCAFFOLDED ────────────────────────────────────────────────────────────
+    console.print(
+        f"[bold yellow]⚠ SCAFFOLDED[/bold yellow] ({len(scaffolded)}) "
+        "Test structure written. You finish the assertion."
+    )
+    for item in scaffolded:
+        sf = item.get("scaffold_file") or item.get("source_file") or ""
+        console.print(f"                 [dim]→[/dim] [yellow]{sf}[/yellow]")
+
+    console.print()
+
+    # ── FLAGGED ───────────────────────────────────────────────────────────────
+    console.print(
+        f"[bold red]🚩 FLAGGED[/bold red]   ({len(flagged)})  "
+        "Can't auto-test. Here's why and where to look."
+    )
+    for item in flagged:
+        src = item.get("source_file") or ""
+        line = item.get("source_line")
+        loc = f"{src}:{line}" if line else src
+        reason = item.get("reason") or "unknown"
+        console.print(
+            f"                 [dim]→[/dim] [red]{loc}[/red]"
+            f"  [dim]reason: {reason}[/dim]"
+        )
+
+    console.print()
+    console.print(Rule())
+
+    # ── PRS summary ───────────────────────────────────────────────────────────
+    color = _TIER_COLOR.get(prs_tier, "white")
+    console.print(
+        f"[bold]Production Readiness Score:[/bold] "
+        f"[bold {color}]{prs_score}/100[/bold {color}]  "
+        f"[dim]({prs_tier_label})[/dim]"
+    )
+    console.print(
+        f"[bold]Edge Case Coverage:[/bold]        "
+        f"{coverage_pct}%  [dim]({len(written) + len(scaffolded)} of {total} cases handled)[/dim]"
+    )
+    if written:
+        console.print(
+            f"[bold]Avg Test Confidence:[/bold]       "
+            f"{avg_confidence:.0f}%  [dim](across {len(written)} WRITTEN tests)[/dim]"
+        )
+    console.print()
+    console.print(f"[dim]Report: {report_path}[/dim]")
+    console.print()


### PR DESCRIPTION
Closes #64

## Summary
- `report/generator.py`: BucketedReport dataclass, write_bucketed_report(), verification_status_to_bucket()
- `ui/console.py`: render_bucketed_summary() - renders WRITTEN/SCAFFOLDED/FLAGGED with confidence tiers and PRS
- `cli.py`: replaces raw stats dump with three-bucket display in _write_scan_report()

## Test plan
- [ ] uv run pytest tests/ -q (299 passed)
- [ ] uv run ruff check quell/ (clean)