### PR TITLE
fix: backup filename collision + multiline Raises parser (#3, #4)

### DIFF
--- a/quell/core/verifier.py
+++ b/quell/core/verifier.py
@@ -188,7 +188,8 @@ class Verifier:
         return f
 
     def _backup(self, src: Path) -> Path:
-        bak = self.backup_dir / f"{src.stem}_{int(time.time())}.bak"
+        import uuid
+        bak = self.backup_dir / f"{src.stem}_{uuid.uuid4().hex}.bak"
         shutil.copy2(src, bak)
         return bak
 

--- a/quell/spec/docstring_reader.py
+++ b/quell/spec/docstring_reader.py
@@ -67,25 +67,50 @@ class DocstringReader:
 
     def _raises(self, doc: str, func: str, path: Path) -> list[Requirement]:
         reqs = []
-        # Match Google "Raises:\n    ExceptionType: condition" blocks
+        # Match Google "Raises:\n    ExceptionType: condition" blocks.
+        # The outer regex captures the entire indented block; we then collect
+        # continuation lines (indented further, no leading ExceptionType:) so
+        # that multi-line conditions are not silently dropped.
         for block in re.finditer(
-            r'Raises?:\s*\n((?:[ \t]+\w[\w.]*[^\n]*\n?)*)', doc, re.MULTILINE
+            r'Raises?:\s*\n((?:[ \t]+[^\n]+\n?)*)', doc, re.MULTILINE
         ):
-            for line in block.group(1).strip().splitlines():
-                line = line.strip()
-                if ':' not in line:
-                    continue
-                exc, _, cond = line.partition(':')
+            current_exc: str | None = None
+            current_cond_parts: list[str] = []
+            current_raw: str = ""
+
+            def _flush() -> None:
+                if current_exc is None:
+                    return
+                cond = " ".join(current_cond_parts).strip()
                 reqs.append(Requirement(
                     id=str(uuid.uuid4())[:8],
-                    description=f"raises {exc.strip()} when {cond.strip()}",
+                    description=f"raises {current_exc} when {cond}",
                     constraint_kind=ConstraintKind.MUST_RAISE,
                     source=SpecSource.DOCSTRING,
                     target_function=func,
                     target_file=path,
-                    expected_behavior=f"raises {exc.strip()}",
-                    raw_spec_text=line,
+                    expected_behavior=f"raises {current_exc}",
+                    raw_spec_text=current_raw,
                 ))
+
+            for raw_line in block.group(1).splitlines():
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                # An exception entry starts with "ExceptionType: ..."
+                if re.match(r'\w[\w.]*\s*:', stripped):
+                    _flush()
+                    current_exc = None
+                    current_cond_parts = []
+                    exc, _, cond_start = stripped.partition(':')
+                    current_exc = exc.strip()
+                    current_raw = stripped
+                    if cond_start.strip():
+                        current_cond_parts.append(cond_start.strip())
+                elif current_exc is not None:
+                    # Continuation line — append to the condition description
+                    current_cond_parts.append(stripped)
+            _flush()
         return reqs
 
     def _boundaries(self, doc: str, func: str, path: Path) -> list[Requirement]:

--- a/tests/unit/test_docstring_reader.py
+++ b/tests/unit/test_docstring_reader.py
@@ -57,3 +57,68 @@ def test_target_function_set_correctly(sample_payments_path: Path) -> None:
 
 def test_source_name() -> None:
     assert DocstringReader().source_name == "docstring"
+
+
+class TestMultilineRaises:
+    """Regression tests for issue #4 — multiline Raises: continuation lines."""
+
+    def _read(self, tmp_path: Path, src: str) -> list:
+        f = tmp_path / "mod.py"
+        f.write_text(src)
+        return DocstringReader().read(f)
+
+    def test_single_line_raises_still_works(self, tmp_path: Path) -> None:
+        src = '''
+def pay(amount):
+    """
+    Raises:
+        ValueError: if amount <= 0
+    """
+'''
+        reqs = self._read(tmp_path, src)
+        assert len(reqs) == 1
+        assert "ValueError" in reqs[0].description
+
+    def test_multiline_condition_captured(self, tmp_path: Path) -> None:
+        src = '''
+def pay(amount, currency):
+    """
+    Raises:
+        ValueError: if amount <= 0,
+            or if currency is unsupported
+    """
+'''
+        reqs = self._read(tmp_path, src)
+        assert len(reqs) == 1
+        assert "ValueError" in reqs[0].description
+        assert "unsupported" in reqs[0].description
+
+    def test_two_exceptions_each_captured(self, tmp_path: Path) -> None:
+        src = '''
+def pay(amount, currency):
+    """
+    Raises:
+        ValueError: if amount <= 0
+        TypeError: if currency is not a string
+    """
+'''
+        reqs = self._read(tmp_path, src)
+        kinds = {r.description for r in reqs}
+        assert any("ValueError" in d for d in kinds)
+        assert any("TypeError" in d for d in kinds)
+
+    def test_second_exception_with_continuation(self, tmp_path: Path) -> None:
+        src = '''
+def pay(amount, currency):
+    """
+    Raises:
+        ValueError: if amount <= 0,
+            or negative
+        TypeError: if currency is not a string,
+            must be ISO 4217
+    """
+'''
+        reqs = self._read(tmp_path, src)
+        assert len(reqs) == 2
+        assert any("negative" in r.description for r in reqs)
+        assert any("ISO 4217" in r.description for r in reqs)

--- a/tests/unit/test_verifier.py
+++ b/tests/unit/test_verifier.py
@@ -157,3 +157,23 @@ class TestVerifyFull:
         )
         result = verifier.verify(req, test)
         assert result.status == VerificationStatus.FAILS_ON_CORRECT
+
+
+class TestBackupFilenameCollision:
+    """Regression tests for issue #3 — backup filename collision."""
+
+    def test_backup_names_are_unique(self, tmp_path: Path, default_config: QuellConfig) -> None:
+        v = Verifier(default_config, project_root=tmp_path)
+        src = tmp_path / "payments.py"
+        src.write_text("def foo(): pass\n")
+        names = {v._backup(src).name for _ in range(5)}
+        assert len(names) == 5, "backup filenames must be unique across concurrent calls"
+
+    def test_backup_uses_hex_not_timestamp(self, tmp_path: Path, default_config: QuellConfig) -> None:
+        v = Verifier(default_config, project_root=tmp_path)
+        src = tmp_path / "payments.py"
+        src.write_text("def foo(): pass\n")
+        bak = v._backup(src)
+        # uuid4 hex is 32 hex chars; a unix timestamp has at most 10 digits
+        suffix = bak.stem.split("_")[-1]
+        assert len(suffix) == 32, f"expected 32-char uuid hex, got: {suffix!r}"


### PR DESCRIPTION
## Summary

- **#3 backup filename collision**: replaced `int(time.time())` with `uuid.uuid4().hex` in `verifier._backup()` — concurrent verifications on the same file within one second now get distinct paths and cannot clobber each other
- **#4 multiline Raises parser**: rewrote `DocstringReader._raises()` to collect continuation lines per entry, so multi-line conditions like "ValueError: if amount <= 0, or unsupported currency" produce one requirement with the full condition instead of truncating at the first newline

Closes #3, #4

## Test plan

- `uv run pytest tests/unit/test_verifier.py::TestBackupFilenameCollision -v` — 2 pass
- `uv run pytest tests/unit/test_docstring_reader.py::TestMultilineRaises -v` — 4 pass
- `uv run pytest tests/unit/ -q` — 358 passed, 0 regressions