### PR TITLE
fix: allow SDK config override to respect CLI --no-llm flag

### DIFF
--- a/quell/cli.py
+++ b/quell/cli.py
@@ -822,7 +822,7 @@ def cmd_check(  # noqa: PLR0913
             except Exception as exc:
                 console.print(f"[yellow]QuellGraph unavailable: {exc}[/yellow]")
 
-    q = Quell(project_root=project_root)
+    q = Quell(project_root=project_root, config=config)
 
     with console.status("[bold blue]Scanning specifications...[/bold blue]"):
         result = q.check(target, sources=src_list, fix=fix)

--- a/quell/sdk.py
+++ b/quell/sdk.py
@@ -48,8 +48,12 @@ class Quell:
         llm: str = "anthropic",
         model: str | None = None,
         project_root: str | Path = ".",
+        config: QuellConfig | None = None,
     ):
-        self.config = QuellConfig(llm_provider=llm)
+        if config is not None:
+            self.config = config
+        else:
+            self.config = QuellConfig(llm_provider=llm)
         if model:
             self.config = self.config.model_copy(update={"llm_model": model})
         self.root = Path(project_root).resolve()


### PR DESCRIPTION
## Summary

When `quell check --no-llm` is run, the CLI correctly loads the config with `llm_provider="none"` from `_load_config()`, but then instantiates `Quell(project_root=project_root)` without passing the resolved config. This causes the SDK to always use the default `llm_provider="anthropic"` config, making `--no-llm` ineffective.

## Fix

Modified `Quell.__init__` to accept an optional `config: QuellConfig | None` parameter. When provided, it uses the config directly instead of building one from `llm`/`model` parameters. The CLI in `cmd_check` now passes the resolved config object to the SDK.

Closes #94.
