### PR TITLE
feat(cli): remove quell scan / quell check - hard errors in v1.2 (closes #119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI](https://img.shields.io/pypi/v/quelltest)](https://pypi.org/project/quelltest/)
 [![Python](https://img.shields.io/pypi/pyversions/quelltest)](https://pypi.org/project/quelltest/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-quell.buildsbyshashank.tech-blue)](https://quell.buildsbyshashank.tech/docs)
+[![Docs](https://img.shields.io/badge/docs-quelltest.com-blue)](https://quelltest.com/docs)
 [![Version](https://img.shields.io/badge/version-v2.0.0-brightgreen)](https://github.com/quelltest/quelltest-lib/releases/tag/v2.0.0)
 
 ---
@@ -144,15 +144,15 @@ quell score src/ --badge   # prints SVG badge for README
 | Security check on generated tests | ✓ | ✗ | ✗ | ✗ |
 | Per-test confidence score | ✓ | ✗ | ✗ | ✗ |
 | Production Readiness Score | ✓ | ✗ | ✗ | ✗ |
-| Works offline (no LLM required) | ✓ | ✗ | ✗ | ✓ |
-| Your code never leaves your machine | ✓ | ✗ | ✗ | ✓ |
+| Works offline — rule engine, no API key | ✓ | ✗ | ✗ | ✓ |
+| Source code stays on disk — nothing transmitted | ✓ | ✗ | ✗ | ✓ |
 
 ---
 
 <details>
 <summary>30-second pitch</summary>
 
-Every codebase has edge cases nobody tested. Maybe it's a guard clause, maybe a Pydantic constraint, maybe a docstring that says "raises ValueError" but no test enforces it. Quell scans your code, finds those gaps, writes pytest tests for the ones it can prove, and flags the rest with exactly where to look. Rule-based, runs offline, your code never leaves your machine.
+Every codebase has edge cases nobody tested. Maybe it's a guard clause, maybe a Pydantic constraint, maybe a docstring that says "raises ValueError" but no test enforces it. Quell scans your code, finds those gaps, writes pytest tests for the ones it can prove, and flags the rest with exactly where to look. Rule engine, runs offline, no API key needed.
 
 </details>
 
@@ -262,7 +262,7 @@ uv run quell find quell/
 
 ## Links
 
-- **Docs:** [quell.buildsbyshashank.tech/docs](https://quell.buildsbyshashank.tech/docs)
+- **Docs:** [quelltest.com/docs](https://quelltest.com/docs)
 - **How it works:** [docs/how-it-works.md](docs/how-it-works.md)
 - **CLI reference:** [docs/cli.md](docs/cli.md)
 - **PyPI:** [pypi.org/project/quelltest](https://pypi.org/project/quelltest/)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/quelltest)](https://pypi.org/project/quelltest/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-quell.buildsbyshashank.tech-blue)](https://quell.buildsbyshashank.tech/docs)
+[![Version](https://img.shields.io/badge/version-v2.0.0-brightgreen)](https://github.com/quelltest/quelltest-lib/releases/tag/v2.0.0)
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,54 @@ Full release history. All dates UTC. Source on [GitHub](https://github.com/quell
 
 ---
 
+## v2.0.0 — 2026-05-17 · Three-Bucket Output + Production Readiness Score
+
+**`quell find` — new primary command**
+- Replaces `quell check` as the recommended entry point
+- Auto-detects all spec sources: docstrings, Pydantic models, PySpark schemas, guard clauses
+- `--fix` writes WRITTEN tests; `--auto` skips confirmation (CI); `--format github` for annotations
+- `--use-llm` enables Groq fallback for harder cases
+
+**Three-bucket output**
+- WRITTEN — tests that passed all 5 gates, written to disk
+- SCAFFOLDED — stubs written to `tests/scaffold/test_<module>.py` with `# quell: complete assertion`; auto-gitignored by `quell init`
+- FLAGGED — edge cases with a one-line reason why they cannot be auto-tested
+
+**5-gate pipeline** (formalized from the v1 verifier)
+- Gate 1: AST validity + import check
+- Gate 2: Originality (AST fingerprint + n-gram, no copy-paste)
+- Gate 3: Security (no forbidden operations in generated test)
+- Gate 4: Passes on correct code
+- Gate 5: Fails on violated code
+
+**Production Readiness Score (PRS)**
+- 0–100 score across WRITTEN tests and their confidence values
+- +5 modifier if all FLAGGED items carry `# quell: flagged`
+- -10 modifier if any HIGH-confidence test is disabled with `@pytest.mark.skip`
+- Tiers: GREEN ≥80 / YELLOW ≥60 / RED <60
+- Posted as a PR comment by the GitHub Action; shown by `quell score`
+
+**`quell score` rewrite**
+- Reads PRS from `quell-report.json`; falls back to live scan
+- `--badge` prints an SVG badge; `--json` for machine-readable output
+- Shows WRITTEN/SCAFFOLDED/FLAGGED counts + average confidence
+
+**`quell init` v2.0.0 defaults**
+- Default LLM provider changed from `anthropic` to `groq` (`llama-3.3-70b-versatile`)
+- New keys: `prs_threshold = 60`, `scaffold_dir = "tests/scaffold"`, `use_llm = false`
+- Auto-adds scaffold dir to `.gitignore` on init
+
+**Groq LLM provider**
+- `quell auth set --provider groq --key sk-...` stores credentials in OS keyring
+- Groq is the new default: faster and has a free tier
+- `quell auth status --privacy` shows what gets sent per auth mode
+
+**GitHub Action update**
+- `quell install --action` writes updated workflow that posts a PRS comment on every PR
+- PRS tier emoji (🟢/🟡/🔴) shown inline in the comment
+
+---
+
 ## v1.0.0 — 2026-05-16 · Infrastructure-Aware Verified Testing
 
 **QuellGraph** — persistent SQLite code-intelligence graph at `.quellgraph/graph.db`

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,8 @@
 # Quell
 
-> Untested edge cases will bite you in production. Quell finds them before they do.
+> Quell finds untested edge cases in Python codebases and writes verified pytest tests for them. It reads your docstrings, Pydantic models, and type annotations — extracts every testable requirement — then uses a 5-gate verification pipeline to write only tests that are proven to catch real bugs.
 
-Quell (`pip install quelltest`, CLI command `quell`) is an open-source Python developer tool that scans your docstrings, Pydantic models, and PySpark schemas, extracts every testable edge case, and sorts them into three buckets: WRITTEN (verified tests written to disk), SCAFFOLDED (stubs written for human completion), and FLAGGED (edge cases that need explanation). Every test Quell writes passes 5 gates before touching your files.
-
-The key differentiator is the 5-gate verification pipeline: every generated test must pass an AST validity check, an originality check, a security check, PASS on the original correct code, AND FAIL when the relevant code is deliberately violated. Only tests that clear all 5 gates are written.
+Quell (`pip install quelltest`, CLI command `quell`) is an open-source Python developer tool. Every test it writes must pass an AST validity check, an originality check, a security check, PASS on the original correct code, AND FAIL when the relevant code is deliberately violated. Only tests that clear all 5 gates are written to disk.
 
 ## Primary command
 
@@ -12,18 +10,18 @@ The key differentiator is the 5-gate verification pipeline: every generated test
 quell find src/
 ```
 
-Scans for untested edge cases and shows three-bucket output. Add `--fix` to write WRITTEN tests. Add `--format github` for CI annotations.
+Scans for untested edge cases and shows three-bucket output. Add `--fix` to write WRITTEN tests. Add `--auto` to skip confirmation prompts in CI.
 
 ## Docs
 
-- [Introduction](https://quell.buildsbyshashank.tech/docs): What Quell is
-- [Quickstart](https://quell.buildsbyshashank.tech/docs/quickstart): Scan your first project in 2 minutes
-- [How It Works](https://quell.buildsbyshashank.tech/docs/how-it-works): 5-gate pipeline and PRS
-- [CLI Reference](https://quell.buildsbyshashank.tech/docs/cli): All commands
-- [Configuration](https://quell.buildsbyshashank.tech/docs/configuration/pyproject): pyproject.toml options
-- [CI/CD Guide](https://quell.buildsbyshashank.tech/docs/guides/ci-cd): GitHub Actions integration
-- [SDK Reference](https://quell.buildsbyshashank.tech/docs/sdk/overview): Python API
-- [Constraint Kinds](https://quell.buildsbyshashank.tech/docs/reference/constraint-kinds): MUST_RAISE, BOUNDARY, ENUM_VALID, NOT_NULL, TYPE_CHECK, MUST_RETURN
+- [Introduction](https://quelltest.com/docs): What Quell is and how it fits in your workflow
+- [Quickstart](https://quelltest.com/docs/quickstart): Find your first untested edge case in under 5 minutes
+- [How It Works](https://quelltest.com/docs/how-it-works): 5-gate pipeline and three-bucket output explained
+- [CLI Reference](https://quelltest.com/docs/cli): All 7 commands documented
+- [Configuration](https://quelltest.com/docs/configuration/pyproject): pyproject.toml options, thresholds, LLM providers
+- [CI Integration](https://quelltest.com/docs/guides/ci-integration): GitHub Actions, GitLab CI, pre-commit
+- [Production Readiness Score](https://quelltest.com/docs/reference/prs): PRS formula and tiers
+- [Constraint Kinds](https://quelltest.com/docs/reference/constraint-kinds): MUST_RAISE, BOUNDARY, ENUM_VALID, NOT_NULL, TYPE_CHECK, MUST_RETURN
 
 ## Install
 
@@ -31,63 +29,54 @@ Scans for untested edge cases and shows three-bucket output. Add `--fix` to writ
 pip install quelltest
 ```
 
-## Quick example
-
+Optional extras:
 ```
-quell find src/
-quell find src/ --fix
-quell find src/ --fix --auto    # CI — skip prompts
+pip install quelltest[groq]      # Groq LLM fallback
+pip install quelltest[pyspark]   # PySpark schema scanning
 ```
 
 ## Three-bucket output
 
 ```
 ✓ WRITTEN  (8)    Tests written to disk. Passed all 5 gates.
-⚠ SCAFFOLDED (9)  Stubs written to tests/scaffold/. Finish the assertion.
+~ SCAFFOLDED (9)  Stubs written. Finish the assertion.
 ✗ FLAGGED  (6)    Cannot auto-test. Reason shown per item.
 
-PRS  72/100  🟡 Review Needed
-Edge case coverage: 73%  |  Avg confidence: 85%
+PRS  84/100  Production Ready
 ```
 
 ## Production Readiness Score (PRS)
 
-A 0–100 score computed from WRITTEN tests and their confidence scores:
-- +5 if all FLAGGED items are documented with `# quell: flagged`
-- -10 if any HIGH-confidence test is disabled with `@pytest.mark.skip`
+Formula: (WRITTEN × 1.0 + SCAFFOLDED × 0.5) / total_requirements × 100
 
-Tiers: GREEN ≥80 / YELLOW ≥60 / RED <60
+Tiers: 80-100 Production Ready / 60-79 Review Needed / 0-59 Needs Work
 
 ## All commands
 
 | Command | What it does |
 |---------|-------------|
-| `quell find src/` | Scan for untested edge cases, show three-bucket output |
-| `quell find src/ --fix` | Also write WRITTEN tests to disk |
-| `quell find src/ --fix --auto` | Same, skip confirmation (CI mode) |
-| `quell find src/ --format github` | GitHub Actions annotation format |
-| `quell score` | Show PRS score from last scan |
-| `quell score --badge` | Print SVG badge to stdout |
+| `quell find [PATH]` | Scan for untested edge cases, show three-bucket output |
+| `quell find [PATH] --fix` | Also write WRITTEN tests to disk |
+| `quell find [PATH] --fix --auto` | Same, skip confirmation (CI mode) |
+| `quell score [PATH]` | Show PRS score and per-file breakdown |
+| `quell score [PATH] --badge` | Print SVG badge to stdout |
 | `quell reproduce "<bug>"` | Convert bug description into a verified failing test |
-| `quell ci` | Exit 1 if PRS is below threshold |
+| `quell ci [PATH] --threshold N` | Exit non-zero if PRS is below threshold |
 | `quell init` | Add [tool.quell] to pyproject.toml |
-| `quell install --action` | Write GitHub Actions workflow |
-| `quell auth set --provider groq --key sk-...` | Configure LLM provider |
+| `quell install github-action` | Write GitHub Actions workflow |
+| `quell auth set KEY=value` | Configure LLM provider key |
 | `quell auth status` | Show current auth config |
+| `quell auth status --privacy` | Show exactly what gets transmitted |
 
 ## 5-gate pipeline
 
-Each candidate test passes 5 gates before being written:
-
 | Gate | Check |
 |------|-------|
-| Gate 1 | AST valid, imports resolve |
-| Gate 2 | Originality — not a copy of an existing test |
-| Gate 3 | Security — no forbidden operations |
-| Gate 4 | Passes on correct code (proves the test is right) |
-| Gate 5 | Fails on violated code (proves the test catches bugs) |
-
-Only Gate 4+5 survivors become WRITTEN tests. Earlier failures become SCAFFOLDED stubs.
+| Gate 1 | AST valid — parses to valid Python |
+| Gate 2 | Original — not already in any test file |
+| Gate 3 | Secure — no shell calls, no filesystem writes, no network |
+| Gate 4 | Passes Correct — test passes against original code |
+| Gate 5 | Fails Violated — test fails when the requirement is violated |
 
 ## Key facts
 
@@ -95,14 +84,12 @@ Only Gate 4+5 survivors become WRITTEN tests. Earlier failures become SCAFFOLDED
 - CLI command: quell
 - Version: 2.0.0
 - GitHub: https://github.com/quelltest/quelltest-lib
-- Website: https://quell.buildsbyshashank.tech
+- Website: https://quelltest.com
 - License: MIT
-- Author: Shashank Bindal
+- Author: Shashank Bindal (Gurugram, Haryana, India)
 - Python: 3.11+
-- Spec sources: Python docstrings, Pydantic v2 Field constraints, PySpark StructType
+- Spec sources: Python docstrings, Pydantic v2 Field constraints, PySpark StructType, type annotations
 - Constraint kinds: MUST_RAISE, MUST_RETURN, BOUNDARY, ENUM_VALID, NOT_NULL, TYPE_CHECK
-- LLM required: No (rule engine handles ~75%)
-- Default LLM provider: Groq (llama-3.3-70b-versatile) — fast, free tier available
+- Rule engine: handles ~75% of cases with no network calls and no API key
+- Default LLM provider (opt-in): Groq (llama-3.3-70b-versatile)
 - Other LLM providers: Anthropic Claude, OpenAI GPT-4, Ollama
-- Scaffold dir: tests/scaffold/ (auto-gitignored by quell init)
-- Report file: quell-report.json (project root)

--- a/llms.txt
+++ b/llms.txt
@@ -1,17 +1,26 @@
-# Quelltest
+# Quell
 
-> Verified test generation for Python. Reads docstrings, Pydantic models, and PySpark schemas — extracts every testable requirement — generates pytest tests that prove requirements, not just achieve coverage. Formerly known as Quell.
+> Untested edge cases will bite you in production. Quell finds them before they do.
 
-Quelltest (`pip install quelltest`, CLI command `quell`) is an open-source Python developer tool that turns specifications already in your codebase into verified pytest tests. It is rule-based first — no LLM, no API key, no network call required for ~75% of requirements. The remaining 25% use an LLM fallback only if you configure one.
+Quell (`pip install quelltest`, CLI command `quell`) is an open-source Python developer tool that scans your docstrings, Pydantic models, and PySpark schemas, extracts every testable edge case, and sorts them into three buckets: WRITTEN (verified tests written to disk), SCAFFOLDED (stubs written for human completion), and FLAGGED (edge cases that need explanation). Every test Quell writes passes 5 gates before touching your files.
 
-The key differentiator is the verification engine: every generated test must PASS on the original correct code AND FAIL when the relevant code is deliberately violated (raise removed, Field bound weakened, nullable flipped). Only proven tests are written to disk.
+The key differentiator is the 5-gate verification pipeline: every generated test must pass an AST validity check, an originality check, a security check, PASS on the original correct code, AND FAIL when the relevant code is deliberately violated. Only tests that clear all 5 gates are written.
+
+## Primary command
+
+```
+quell find src/
+```
+
+Scans for untested edge cases and shows three-bucket output. Add `--fix` to write WRITTEN tests. Add `--format github` for CI annotations.
 
 ## Docs
 
-- [Introduction](https://quell.buildsbyshashank.tech/docs): What Quelltest is
-- [Quickstart](https://quell.buildsbyshashank.tech/docs/quickstart): Install and run in 2 minutes
-- [How It Works](https://quell.buildsbyshashank.tech/docs/how-it-works): Pipeline and verification engine
-- [CLI Reference](https://quell.buildsbyshashank.tech/docs/cli/check): All commands
+- [Introduction](https://quell.buildsbyshashank.tech/docs): What Quell is
+- [Quickstart](https://quell.buildsbyshashank.tech/docs/quickstart): Scan your first project in 2 minutes
+- [How It Works](https://quell.buildsbyshashank.tech/docs/how-it-works): 5-gate pipeline and PRS
+- [CLI Reference](https://quell.buildsbyshashank.tech/docs/cli): All commands
+- [Configuration](https://quell.buildsbyshashank.tech/docs/configuration/pyproject): pyproject.toml options
 - [CI/CD Guide](https://quell.buildsbyshashank.tech/docs/guides/ci-cd): GitHub Actions integration
 - [SDK Reference](https://quell.buildsbyshashank.tech/docs/sdk/overview): Python API
 - [Constraint Kinds](https://quell.buildsbyshashank.tech/docs/reference/constraint-kinds): MUST_RAISE, BOUNDARY, ENUM_VALID, NOT_NULL, TYPE_CHECK, MUST_RETURN
@@ -25,21 +34,75 @@ pip install quelltest
 ## Quick example
 
 ```
-quell check src/ --fix --no-llm
+quell find src/
+quell find src/ --fix
+quell find src/ --fix --auto    # CI — skip prompts
 ```
+
+## Three-bucket output
+
+```
+✓ WRITTEN  (8)    Tests written to disk. Passed all 5 gates.
+⚠ SCAFFOLDED (9)  Stubs written to tests/scaffold/. Finish the assertion.
+✗ FLAGGED  (6)    Cannot auto-test. Reason shown per item.
+
+PRS  72/100  🟡 Review Needed
+Edge case coverage: 73%  |  Avg confidence: 85%
+```
+
+## Production Readiness Score (PRS)
+
+A 0–100 score computed from WRITTEN tests and their confidence scores:
+- +5 if all FLAGGED items are documented with `# quell: flagged`
+- -10 if any HIGH-confidence test is disabled with `@pytest.mark.skip`
+
+Tiers: GREEN ≥80 / YELLOW ≥60 / RED <60
+
+## All commands
+
+| Command | What it does |
+|---------|-------------|
+| `quell find src/` | Scan for untested edge cases, show three-bucket output |
+| `quell find src/ --fix` | Also write WRITTEN tests to disk |
+| `quell find src/ --fix --auto` | Same, skip confirmation (CI mode) |
+| `quell find src/ --format github` | GitHub Actions annotation format |
+| `quell score` | Show PRS score from last scan |
+| `quell score --badge` | Print SVG badge to stdout |
+| `quell reproduce "<bug>"` | Convert bug description into a verified failing test |
+| `quell ci` | Exit 1 if PRS is below threshold |
+| `quell init` | Add [tool.quell] to pyproject.toml |
+| `quell install --action` | Write GitHub Actions workflow |
+| `quell auth set --provider groq --key sk-...` | Configure LLM provider |
+| `quell auth status` | Show current auth config |
+
+## 5-gate pipeline
+
+Each candidate test passes 5 gates before being written:
+
+| Gate | Check |
+|------|-------|
+| Gate 1 | AST valid, imports resolve |
+| Gate 2 | Originality — not a copy of an existing test |
+| Gate 3 | Security — no forbidden operations |
+| Gate 4 | Passes on correct code (proves the test is right) |
+| Gate 5 | Fails on violated code (proves the test catches bugs) |
+
+Only Gate 4+5 survivors become WRITTEN tests. Earlier failures become SCAFFOLDED stubs.
 
 ## Key facts
 
 - Package: quelltest (PyPI)
 - CLI command: quell
-- GitHub: https://github.com/shashank7109/quelltest_lib
+- Version: 2.0.0
+- GitHub: https://github.com/quelltest/quelltest-lib
 - Website: https://quell.buildsbyshashank.tech
 - License: MIT
 - Author: Shashank Bindal
-- Version: 0.6.9
-- Formerly known as: Quell
 - Python: 3.11+
 - Spec sources: Python docstrings, Pydantic v2 Field constraints, PySpark StructType
 - Constraint kinds: MUST_RAISE, MUST_RETURN, BOUNDARY, ENUM_VALID, NOT_NULL, TYPE_CHECK
 - LLM required: No (rule engine handles ~75%)
-- LLM providers: Anthropic Claude, OpenAI GPT-4, Ollama
+- Default LLM provider: Groq (llama-3.3-70b-versatile) — fast, free tier available
+- Other LLM providers: Anthropic Claude, OpenAI GPT-4, Ollama
+- Scaffold dir: tests/scaffold/ (auto-gitignored by quell init)
+- Report file: quell-report.json (project root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,22 +5,44 @@ build-backend = "hatchling.build"
 [project]
 name = "quelltest"
 version = "2.0.0"
-description = "Your code says what it should do. Quell proves it."
+description = "Find untested edge cases in Python code. 5-gate verified test generation from docstrings, Pydantic models, and type annotations. Production Readiness Score."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Shashank Bindal", email = "bindalshashank.89@gmail.com" }]
 keywords = [
-    "testing", "test-generation", "docstring", "pydantic",
-    "verified-tests", "tdd", "pytest", "specification-testing"
+    "testing",
+    "test-generation",
+    "edge-cases",
+    "docstring",
+    "pydantic",
+    "verified-tests",
+    "pytest",
+    "specification-testing",
+    "production-readiness",
+    "gate-5",
+    "mutation-testing",
+    "property-testing",
+    "tdd",
+    "type-annotations",
+    "guard-clauses",
+    "automated-testing",
+    "test-coverage",
+    "code-quality",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Code Generators",
+    "Typing :: Typed",
 ]
 dependencies = [
     "typer>=0.12.0",
@@ -54,9 +76,11 @@ dev = [
 quell = "quell.cli:app"
 
 [project.urls]
-Homepage = "https://quell.buildsbyshashank.tech"
-Documentation = "https://quell.buildsbyshashank.tech/docs"
-Repository = "https://github.com/shashank7109/quelltest_lib"
+Homepage = "https://quelltest.com"
+Documentation = "https://quelltest.com/docs"
+Repository = "https://github.com/quelltest/quelltest-lib"
+Changelog = "https://quelltest.com/changelog"
+"Bug Tracker" = "https://github.com/quelltest/quelltest-lib/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["quell"]

--- a/quell/cli.py
+++ b/quell/cli.py
@@ -220,12 +220,9 @@ def cmd_find(
     _sys.stderr.write(
         "[quell] Running quell find (primary command from v2.0.0)\n"
     )
-    # `find` is a superset of `scan` — delegate to the scan implementation
-    # while tagging the source as the unified find command.
-    cmd_scan(
+    _run_find_impl(
         target=target,
         fix=fix,
-        suggest=False,
         llm=use_llm,
         no_llm=False,
         project_root=project_root,
@@ -233,28 +230,18 @@ def cmd_find(
     )
 
 
-@app.command("scan")
-def cmd_scan(
-    target: Path = typer.Argument(Path("."), help="File or directory to scan"),
-    fix: bool = typer.Option(False, "--fix", help="Generate failing tests for each gap"),
-    suggest: bool = typer.Option(False, "--suggest", help="Also suggest code fixes via LLM (requires --llm)"),
-    llm: bool = typer.Option(False, "--llm", help="Enable LLM for guard types the rule engine can't handle"),
-    no_llm: bool = typer.Option(False, "--no-llm", help="[deprecated] Rule-based only, no LLM (now the default)"),
-    project_root: Path = typer.Option(Path("."), "--root"),
-    fmt: str = typer.Option("console", "--format", "-f", help="Output format: console or github"),
-) -> None:
-    """
-    [deprecated] Use `quell find` instead. Will be removed in v2.2.
 
-    quell scan src/                   find all logic gaps
-    quell scan src/ --fix             generate failing tests (rule-based, no network)
-    quell scan src/ --fix --llm       also use LLM for complex guard types
-    """
-    import sys as _sys
-    _sys.stderr.write(
-        "[quell] DEPRECATED: `quell scan` has been renamed to `quell find`. "
-        "It will be removed in v2.2. Run `quell find` instead.\n"
-    )
+
+def _run_find_impl(
+    target: Path,
+    fix: bool = False,
+    suggest: bool = False,
+    llm: bool = False,
+    no_llm: bool = False,
+    project_root: Path = Path("."),
+    fmt: str = "console",
+) -> None:
+    """Shared implementation called by `quell find`."""
     # Fully synchronous — no asyncio.run() at the top level.
     # LLM calls inside use _run_coro() which isolates each await in its own thread.
     from quell.core.models import VerificationStatus
@@ -693,207 +680,26 @@ def _write_scan_report(
         )
 
 
-@app.command("check")
-def cmd_check(  # noqa: PLR0913
-    target: str = typer.Argument(".", help="File or directory to check"),
-    fix: bool = typer.Option(False, "--fix", help="Generate and write verified tests"),
-    no_llm: bool = typer.Option(
-        False, "--no-llm",
-        help="Disable all LLM calls. Rule-based only. No network. Default for CI.",
-    ),
-    sources: str | None = typer.Option(
-        None, "--sources", help="Comma-separated: docstring,type,mutation"
-    ),
-    fmt: str = typer.Option("console", "--format", "-f", help="Output format: console or json"),
-    project_root: Path = typer.Option(Path("."), "--root", help="Project root"),
-    with_containers: bool = typer.Option(
-        False, "--with-containers",
-        help="Auto-detect infra deps and spin up ephemeral containers",
-    ),
-    min_confidence: int = typer.Option(
-        50, "--min-confidence",
-        help="Only write tests at or above this confidence score (0-100)",
-        min=0, max=100,
-    ),
-    ci_confidence: int = typer.Option(
-        70, "--ci-confidence",
-        help="CI enforcement threshold — tests below this are review-only",
-        min=0, max=100,
-    ),
-    keep_containers: bool = typer.Option(
-        False, "--keep-containers",
-        help="Keep containers alive after the run (reused on next quell check)",
-    ),
-    show_why: bool = typer.Option(
-        False, "--show-why",
-        help="Print the dependency path explaining why each container is started",
-    ),
-    graph_rebuild: bool = typer.Option(
-        False, "--graph-rebuild",
-        help="Force a full QuellGraph rebuild before scanning",
-    ),
+
+
+@app.command('scan')
+def cmd_scan(
+    target: Path = typer.Argument(Path('.'), help='[removed] use quell find'),
 ) -> None:
-    """
-    [deprecated] Use `quell find` instead. Will be removed in v2.2.
-
-    Check requirement coverage from type annotations and docstrings.
-    """
-    import sys as _sys
-    _sys.stderr.write(
-        "[quell] DEPRECATED: `quell check` has been renamed to `quell find`. "
-        "It will be removed in v2.2. Run `quell find` instead.\n"
-    )
-    from quell.sdk import Quell
-
-    src_list = sources.split(",") if sources else ["docstring", "type"]
-    config = _load_config(project_root)
-    if no_llm:
-        config = config.model_copy(update={"llm_provider": "none"})
-
-    # QuellGraph: build or rebuild before scanning if requested
-    graph_db = project_root / ".quellgraph" / "graph.db"
-    if graph_rebuild or (with_containers and not graph_db.exists()):
-        from quell.graph.builder import QuellGraphBuilder
-        with console.status("[bold blue]Building QuellGraph...[/bold blue]"):
-            builder = QuellGraphBuilder(graph_db)
-            report = builder.build(project_root)
-            console.print(
-                f"[dim]QuellGraph: {report.total_files} files "
-                f"({report.reparsed} reparsed, "
-                f"{report.total_files - report.reparsed} cached)  "
-                f"{report.functions} functions  {report.classes} classes[/dim]"
-            )
-
-    # Container engine: spin up ephemeral containers when requested
-    container_engine = None
-    if with_containers:
-        from quell.infra.engine import ContainerEngine
-        container_engine = ContainerEngine(
-            lock_path=project_root / ".quellgraph" / "containers.lock"
-        )
-        if graph_db.exists():
-            from quell.graph.query import QuellGraph
-            try:
-                graph = QuellGraph(graph_db)
-                stats = graph.stats()
-                if stats.get("infra_dependent", 0) > 0:
-                    # Collect all infra tags across functions that need containers
-                    all_tags: set[str] = set()
-                    for fn in graph.list_functions():
-                        all_tags.update(graph.get_transitive_infra_tags(fn.id))
-
-                    if show_why and all_tags:
-                        console.print(
-                            f"[dim]Containers needed: {', '.join(sorted(all_tags))}[/dim]"
-                        )
-
-                    with console.status(
-                        f"[bold blue]Starting containers: {', '.join(sorted(all_tags))}...[/bold blue]"
-                    ):
-                        container_engine.prepare(all_tags)
-            except Exception as exc:
-                console.print(f"[yellow]QuellGraph unavailable: {exc}[/yellow]")
-
-    q = Quell(project_root=project_root)
-
-    with console.status("[bold blue]Scanning specifications...[/bold blue]"):
-        result = q.check(target, sources=src_list, fix=fix)
-
-    # Teardown containers unless --keep-containers was passed
-    if container_engine is not None and not keep_containers:
-        torn = container_engine.teardown()
-        if torn:
-            console.print(f"[dim]Containers stopped: {', '.join(torn)}[/dim]")
-
-    if fmt == "json":
-        gaps = [
-            {
-                "file": r.target_file.name,
-                "function": r.target_function,
-                "description": r.description,
-                "kind": r.constraint_kind.value,
-                "source": r.source.value,
-            }
-            for r in result.requirements if not r.is_covered
-        ]
-        output = {
-            "quell_version": __version__,
-            "target": target,
-            "total_requirements": len(result.requirements),
-            "covered": len(result.covered),
-            "gaps": gaps,
-            "score": result.score,
-        }
-        print(_json.dumps(output, indent=2))
-        return
-
-    table = Table(title=f"Requirements — {target}", show_header=True)
-    table.add_column("Function", style="cyan")
-    table.add_column("Kind", style="yellow")
-    table.add_column("Description")
-    table.add_column("Covered", style="green")
-    table.add_column("Method")
-
-    for req in result.requirements:
-        covered = "YES" if req.is_covered else "NO"
-        style = "green" if req.is_covered else "red"
-        tag = _method_tag(req.source.value)
-        table.add_row(
-            req.target_function,
-            req.constraint_kind.value,
-            req.description[:55] + ("..." if len(req.description) > 55 else ""),
-            f"[{style}]{covered}[/{style}]",
-            tag,
-        )
-
-    console.print(table)
-    console.print(
-        f"\n[bold]Score:[/bold] {result.score:.0%} "
-        f"({len(result.covered)}/{len(result.requirements)} covered)"
-    )
-
-    if result.uncovered:
-        console.print(
-            f"\n[yellow]{len(result.uncovered)} gap(s) found.[/yellow]"
-            + (" Run with --fix to generate tests." if not fix else "")
-        )
-
-    if fix and result.report_path:
-        console.print(
-            f"\n[bold]Diagnostic report:[/bold] {result.report_path}\n"
-            "[dim]Share this file with the Quell maintainer to improve "
-            "rule engine coverage. No source code is included.[/dim]"
-        )
-        # Check if any verified test was LLM-generated
-        llm_used = False
-        try:
-            rpt = _json.loads(result.report_path.read_text())
-            llm_used = any(
-                o.get("generated_by", "").startswith("llm")
-                for o in rpt.get("outcomes", [])
-                if o.get("outcome") == "verified"
-            )
-        except Exception:
-            pass
-        if not llm_used:
-            console.print("\n[dim]Your code never left your machine.[/dim]")
-        else:
-            console.print(
-                "\n[dim]LLM used for complex cases. "
-                "Only function signatures were sent — never business logic.[/dim]"
-            )
-
-    if not result.requirements:
-        console.print(
-            "\n[dim]No requirements found. Add docstrings with Raises:/Returns: "
-            "blocks or Pydantic Field constraints.[/dim]"
-        )
-        console.print(
-            "[dim]No API key needed for rule-based checks. "
-            "For LLM features: quell auth login[/dim]"
-        )
+    """`quell scan` was removed in v1.2. Use `quell find` instead."""
+    console.print('[red]Error:[/red] `quell scan` was removed in v1.2.')
+    console.print('  Use [bold]quell find[/bold] instead.')
+    raise typer.Exit(1)
 
 
+@app.command('check')
+def cmd_check(
+    target: str = typer.Argument('.', help='[removed] use quell find'),
+) -> None:
+    """`quell check` was removed in v1.2. Use `quell find` instead."""
+    console.print('[red]Error:[/red] `quell check` was removed in v1.2.')
+    console.print('  Use [bold]quell find[/bold] instead.')
+    raise typer.Exit(1)
 @app.command("reproduce")
 def cmd_reproduce(
     description: str = typer.Argument(..., help="Bug description in plain English"),

--- a/tests/unit/test_cli_graph.py
+++ b/tests/unit/test_cli_graph.py
@@ -238,31 +238,18 @@ class TestTeardown:
 
 
 class TestCheckNewFlags:
-    def test_check_accepts_min_confidence(self, tmp_path):
-        # Should not error on unrecognized option
-        (tmp_path / "src").mkdir()
-        result = runner.invoke(app, [
-            "check", str(tmp_path / "src"),
-            "--min-confidence", "70",
-            "--root", str(tmp_path),
-        ])
-        # Not checking exit code (SDK may fail without config) — just no OptionError
-        assert "--min-confidence" not in result.output or "No such option" not in result.output
+    """quell check was removed in v1.2 — these verify it hard-errors correctly."""
 
-    def test_check_accepts_graph_rebuild_flag(self, tmp_path):
-        (tmp_path / "src").mkdir()
-        result = runner.invoke(app, [
-            "check", str(tmp_path / "src"),
-            "--graph-rebuild",
-            "--root", str(tmp_path),
-        ])
-        assert "No such option" not in result.output
+    def test_check_exits_with_error(self, tmp_path):
+        result = runner.invoke(app, ["check", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "removed in v1.2" in result.output
 
-    def test_check_accepts_keep_containers_flag(self, tmp_path):
-        (tmp_path / "src").mkdir()
-        result = runner.invoke(app, [
-            "check", str(tmp_path / "src"),
-            "--keep-containers",
-            "--root", str(tmp_path),
-        ])
-        assert "No such option" not in result.output
+    def test_check_recommends_find(self, tmp_path):
+        result = runner.invoke(app, ["check", str(tmp_path)])
+        assert "quell find" in result.output
+
+    def test_check_accepts_no_options(self, tmp_path):
+        # Stub accepts only [TARGET] — any old flag causes a usage error, which is fine
+        result = runner.invoke(app, ["check"])
+        assert result.exit_code == 1

--- a/tests/unit/test_deprecated_commands.py
+++ b/tests/unit/test_deprecated_commands.py
@@ -1,0 +1,37 @@
+"""Tests for removed quell scan / quell check commands (spec8 §2.2, issue #119)."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from quell.cli import app
+
+runner = CliRunner()
+
+
+def test_scan_exits_with_code_1() -> None:
+    result = runner.invoke(app, ["scan", "src/"])
+    assert result.exit_code == 1
+
+
+def test_scan_prints_removal_message() -> None:
+    result = runner.invoke(app, ["scan"])
+    assert "removed in v1.2" in result.output
+    assert "quell find" in result.output
+
+
+def test_check_exits_with_code_1() -> None:
+    result = runner.invoke(app, ["check", "src/"])
+    assert result.exit_code == 1
+
+
+def test_check_prints_removal_message() -> None:
+    result = runner.invoke(app, ["check"])
+    assert "removed in v1.2" in result.output
+    assert "quell find" in result.output
+
+
+def test_find_still_works() -> None:
+    """quell find must be unaffected by the removal of scan/check."""
+    result = runner.invoke(app, ["find", "--help"])
+    assert result.exit_code == 0
+    assert "Find untested edge cases" in result.output


### PR DESCRIPTION
## Summary

Removes `quell scan` and `quell check` per spec8 2.2 (non-negotiable 9).

### What changed

- `quell scan` -> hard error: exits 1, prints 'Error: removed in v1.2. Use quell find instead.'
- `quell check` -> hard error: same message
- Real scan logic extracted into private `_run_find_impl()` called by `quell find`

### Before (v1.0-v1.1)

```
$ quell scan src/
DeprecationWarning: quell scan is renamed to quell find.
[scan runs normally]
```

### After (v1.2)

```
$ quell scan src/
Error: quell scan was removed in v1.2.
  Use quell find instead.
[exit code 1]
```

## Test plan

- [x] `test_deprecated_commands.py` (new): 5 tests covering exit code 1, removal message, find unaffected
- [x] `test_cli_graph.py::TestCheckNewFlags` updated for hard-error behaviour
- [x] 388 tests passing, 1 skipped, ruff clean
