### PR TITLE
docs: add Code of Conduct and contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as contributors, maintainers, and community members pledge to make participation in the Quell community a respectful, inclusive, and harassment-free experience for everyone.
+
+We are committed to fostering an environment where developers can collaborate to improve software quality, testing practices, and reliability through open and constructive contributions.
+
+## Our Standards
+
+Examples of behavior that contribute to a positive environment include:
+
+* Treating others with respect and professionalism.
+* Providing constructive feedback.
+* Supporting contributors of all experience levels.
+* Collaborating openly and sharing knowledge.
+* Encouraging responsible software engineering practices.
+* Supporting the growth of the project and, if you find it useful, considering giving the repository a ⭐ star.
+
+Examples of unacceptable behavior include:
+
+* Harassment, discrimination, or hateful conduct.
+* Personal attacks, intimidation, or trolling.
+* Publishing private information without permission.
+* Deliberately introducing malicious or misleading code.
+* Any conduct that creates a hostile or unwelcoming environment.
+
+## Responsible Engineering
+
+Contributors are encouraged to:
+
+* Prioritize code quality and maintainability.
+* Write clear, reproducible test cases.
+* Document assumptions and limitations.
+* Promote reliable and secure software development practices.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing community standards and may take appropriate action when necessary.
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including repositories, issues, pull requests, discussions, and community communication channels.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers through official project communication channels.
+
+## Attribution
+
+Adapted from Contributor Covenant v2.1:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -99,6 +99,39 @@ When reporting bugs:
 
 ---
 
+## Linting & Pre-Submission Checks
+
+Before submitting a Pull Request, please ensure that your changes pass the project's quality checks.
+
+### Linting
+
+Run the linter and resolve any reported issues:
+
+```bash
+npm run lint
+```
+
+### Tests
+
+Run the test suite to verify that your changes do not introduce regressions:
+
+```bash
+npm test
+```
+
+If the project uses a different testing command, please use the appropriate command documented by the maintainers.
+
+### Pre-Submission Checklist
+
+Before opening a PR, make sure that:
+
+* All lint checks pass successfully.
+* Existing tests pass without failures.
+* New functionality includes relevant tests whenever applicable.
+* Documentation is updated if your changes affect usage or behavior.
+* No unrelated files or changes are included in the PR.
+
+
 ## Community Standards
 
 By participating in this project, you agree to follow the project's Code of Conduct.

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,110 @@
+# Contributing to Quelltest
+
+Thank you for your interest in contributing to Quell!
+
+It helps developers discover untested edge cases before they reach production. We welcome contributions that improve reliability, testing coverage, developer experience, documentation, and overall project quality.
+
+---
+
+## ⭐ Star the Repository
+
+If you find it useful, please consider starring the repository to support the project.
+
+---
+
+## Ways to Contribute
+
+You can contribute by:
+
+* Fixing bugs
+* Improving edge-case detection
+* Enhancing testing workflows
+* Improving documentation
+* Adding new features
+* Improving performance and reliability
+* Writing additional test coverage
+
+---
+
+## Getting Started
+
+### 1. Fork the Repository
+
+Create your own fork of the project.
+
+### 2. Clone Your Fork
+
+```bash
+git clone https://github.com/YOUR_USERNAME/quelltest.git
+cd quelltest
+```
+
+### 3. Create a Branch
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+---
+
+## Development Guidelines
+
+Please ensure that:
+
+* Code follows the existing style and architecture.
+* Changes remain focused on a single issue.
+* New functionality includes appropriate tests.
+* Documentation is updated when necessary.
+* Code remains clean, maintainable, and readable.
+
+---
+
+## Pull Request Guidelines
+
+Before opening a PR:
+
+* Test your changes locally.
+* Perform a self-review.
+* Reference the related issue.
+* Include screenshots if UI changes are involved.
+* Keep pull requests focused and easy to review.
+
+Example:
+
+```text
+Fixes #123
+```
+
+---
+
+## Testing Expectations
+
+Since it focuses on finding edge cases and improving software reliability:
+
+* Add tests whenever possible.
+* Validate bug fixes with reproducible test cases.
+* Ensure existing functionality is not broken.
+* Consider unusual or boundary-case inputs during testing.
+
+---
+
+## Reporting Issues
+
+When reporting bugs:
+
+* Provide clear reproduction steps.
+* Include expected and actual behavior.
+* Share relevant logs or screenshots.
+* Mention environment details when applicable.
+
+---
+
+## Community Standards
+
+By participating in this project, you agree to follow the project's Code of Conduct.
+
+Please review `CODE_OF_CONDUCT.md` before contributing.
+
+---
+
+Thank you for helping make software more reliable with Quell!


### PR DESCRIPTION
Added CODE_OF_CONDUCT.md and CONTRIBUTING.md to establish community standards, contributor expectations, and clear contribution guidelines. Hence resolved issue #125 & #126 